### PR TITLE
Remove the disturbing ".dmg" Mounting Verification

### DIFF
--- a/.osx
+++ b/.osx
@@ -28,6 +28,9 @@ defaults write -g ApplePressAndHoldEnabled -bool false
 # Disable OS X Lion auto-correct
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
 
+# Disable OS X DMG Mounting Verification
+defaults write com.apple.frameworks.diskimages skip-verify true
+
 # Reset Launchpad
 rm ~/Library/Application\ Support/Dock/*.db
 


### PR DESCRIPTION
It save’s you a lot of time. Almost every time, a broken .dmg file didn’t open at all. I don’t think this verification really worth the time you save when opening big .dmg files.
