### PR TITLE
Removing duplicate `set mark-symlinked-directories on` settings.

### DIFF
--- a/.inputrc
+++ b/.inputrc
@@ -1,9 +1,6 @@
 # Make Tab autocomplete regardless of filename case
 set completion-ignore-case on
 
-# Append a slash when autocompleting symbolic links to directories
-set mark-symlinked-directories on
-
 # List all matches in case multiple possible completions are possible
 set show-all-if-ambiguous on
 


### PR DESCRIPTION
You've got `set mark-symlinked-directories on` showing up twice :)
