### PR TITLE
Shift the '-type f' argument before the '-name' argument in `find`

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -53,7 +53,7 @@ type -t md5sum > /dev/null || alias md5sum="md5"
 alias c="tr -d '\n' | pbcopy"
 
 # Recursively delete `.DS_Store` files
-alias cleanup="find . -name '*.DS_Store' -type f -ls -delete"
+alias cleanup="find . -type f -name '*.DS_Store' -ls -delete"
 
 # File size
 alias fs="stat -f \"%z bytes\""


### PR DESCRIPTION
 to make it more efficient.
