### PR TITLE
Added default to add a spacer to the dock.

### DIFF
--- a/.osx
+++ b/.osx
@@ -13,6 +13,9 @@ defaults write com.apple.dock autohide -bool true
 # Make Dock icons of hidden applications translucent
 defaults write com.apple.dock showhidden -bool true
 
+# Add a spacer to the dock
+defaults write com.apple.dock persistent-apps -array-add '{tile-data={}; tile-type="spacer-tile";}'
+
 # Enable iTunes track notifications in the Dock
 defaults write com.apple.dock itunes-notifications -bool true
 


### PR DESCRIPTION
I've used this on Snow Leopard and Lion and it works great.  It may be worth documenting that you need to run "killall Dock" after many of these to get them to show up.

Thanks for the list.
