### PR TITLE
Added QuickLook text selection to .osx

### DIFF
--- a/.osx
+++ b/.osx
@@ -199,6 +199,9 @@ file=/Applications/Dropbox.app/Contents/Resources/check.icns
 [ -e "$file" ] && mv -f "$file" "$file.bak"
 unset file
 
+# Enable the ability to highlight text in QuickLook
+defaults write com.apple.finder QLEnableTextSelection -bool TRUE
+
 # Fix for the ancient UTF-8 bug in QuickLook (http://mths.be/bbo)
 # Commented out, as this is known to cause problems when saving files in Adobe Illustrator CS5 :(
 #echo "0x08000100:0" > ~/.CFUserTextEncoding


### PR DESCRIPTION
Created another entry for the ability to select text when viewing a
document in QuickLook
