### PR TITLE
Fix error thrown when Reseting Launchpad in some conditions

### DIFF
--- a/.osx
+++ b/.osx
@@ -219,7 +219,7 @@ defaults write com.apple.mail AddressesIncludeNameOnPasteboard -bool false
 defaults write com.apple.dashboard devmode -bool true
 
 # Reset Launchpad
-[ -e ~/Library/Application\ Support/Dock/*.db ] && rm ~/Library/Application\ Support/Dock/*.db
+find ~/Library/Application\ Support/Dock -name "*.db" -maxdepth 1 -delete
 
 # Prevent Time Machine from prompting to use new hard drives as backup volume
 defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true


### PR DESCRIPTION
When multiple _.db files exist in `~/Library/Application Support/Dock/` ,
`[ -e ~/Library/Application\ Support/Dock/_.db ]` would throw an error.

fixes #56
