### PR TITLE
More straightforward alias for listing only directories

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -21,7 +21,7 @@ alias l="ls -Gl"
 alias la="ls -Gla"
 
 # List only directories
-alias lsd='ls -l | grep "^d"'
+alias lsd='ls -ld */'
 
 # Always use color output for `ls`
 if [[ "$OSTYPE" =~ ^darwin ]]; then


### PR DESCRIPTION
No need to pipe ls through grep to list only directories. Plus, this patch retains directory colours.
