### PR TITLE
Make directories with parents

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -27,6 +27,9 @@ alias la="ls -Gla"
 # List only directories
 alias lsd='ls -l | grep "^d"'
 
+# Make directories with parents
+alias mkdir="mkdir --parents --verbose"
+
 # Always use color output for `ls`
 if [[ "$OSTYPE" =~ ^darwin ]]; then
 	alias ls="command ls -G"


### PR DESCRIPTION
```
$ mkdir foo/bar/baz/{wibble,wubble,wobble}
mkdir: created directory `foo'
mkdir: created directory `foo/bar'
mkdir: created directory `foo/bar/baz'
mkdir: created directory `foo/bar/baz/wibble'
mkdir: created directory `foo/bar/baz/wubble'
mkdir: created directory `foo/bar/baz/wobble'
```
