### PR TITLE
.vimrc: Respect modeline by default

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -68,6 +68,9 @@ if exists("&relativenumber")
 endif
 " Start scrolling three lines before the horizontal window border
 set scrolloff=3
+" Respect modeline in files
+set modeline
+set modelines=4
 
 " Strip trailing whitespace (,ss)
 function! StripWhitespace()


### PR DESCRIPTION
`:help modeline`

This feature is very useful for enforcing consistent whitespacing (tab vs space), indenting (4 vs 2 spaces) and many others.

By enabling this setting, users can opt into modeline by commenting their files. If vim does not detect anything in the first 4 lines of any file, it will simply ignore and use default settings as specificed by the .vimrc file.
