### PR TITLE
.vimrc: Enable local .vimrc files and disable unsafe commands in local .vimrc files

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -29,6 +29,9 @@ endif
 " Respect modeline in files
 set modeline
 set modelines=4
+" Enable per-directory .vimrc files and disable unsafe commands in them
+set exrc
+set secure
 " Enable line numbers
 set number
 " Enable syntax highlighting


### PR DESCRIPTION
As suggested by @necolas (see comments in issue #86). 

I have tested this in one of my projects and indeed, it works like a charm! This is what I have wanted for some years now.

I have kept `modeline` support as it is opt-in and I have a few individual files that use it at the moment. Leaving it for @mathiasbynens to decide whether `modeline` support should stay in there.
