### PR TITLE
save and restore last cursor position in vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -19,6 +19,11 @@ let mapleader=","
 " Don’t add empty newlines at the end of files
 set binary
 set noeol
+" read/write a ~/.viminfo file, don't store more
+" than 20 files and 50 lines/commands per file
+set viminfo='20,\"50,:50,%,n~/.viminfo
+" keep 50 lines of command line history
+set history=50
 " Centralize backups, swapfiles and undo history
 set backupdir=~/.vim/backups
 set directory=~/.vim/swaps
@@ -93,4 +98,12 @@ if has("autocmd")
 	filetype on
 	" Treat .json files as .js
 	autocmd BufNewFile,BufRead *.json setfiletype json syntax=javascript
+	augroup cursor
+	autocmd!
+	" When editing a file, always jump to the last cursor position
+	autocmd BufReadPost *
+	\ if line("'\"") > 0 && line ("'\"") <= line("$") |
+	\   exe "normal! g'\"" |
+	\ endif
+	augroup END
 endif


### PR DESCRIPTION
This sets vim to save the cursor position on close/write and restores it on re-opening.
- The <code>set viminfo</code> part is to unify and explicitly declare the .viminfo file (~/.viminfo is the default though)
- The <code>augroup cursor</code> part restores the cursor
  
  The additional check is to ensure, that the restoring works properly on files with only one line
