### PR TITLE
.osx: Enable HiDPI display modes

### DIFF
--- a/.osx
+++ b/.osx
@@ -122,6 +122,9 @@ defaults write com.apple.screencapture disable-shadow -bool true
 # Enable subpixel font rendering on non-Apple LCDs
 defaults write NSGlobalDomain AppleFontSmoothing -int 2
 
+# Enable HiDPI display modes without using Quartz Debug (requires restart)
+sudo defaults write /Library/Preferences/com.apple.windowserver DisplayResolutionEnabled -bool YES;
+
 ###############################################################################
 # Finder                                                                      #
 ###############################################################################


### PR DESCRIPTION
Added the line enabling HiDPI display modes without using Quartz Debug.
