### PR TITLE
.aliases: Launch iOS Simulator

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -101,7 +101,7 @@ alias spoton="sudo mdutil -a -i on"
 alias plistbuddy="/usr/libexec/PlistBuddy"
 
 # Launch iOS Simulator
-alias simulator="open /Applications/Xcode.app/Contents/Applications/iPhone\ Simulator.app"
+alias ios="open /Applications/Xcode.app/Contents/Applications/iPhone\ Simulator.app"
 
 # One of @janmoesen’s ProTip™s
 for method in GET HEAD POST PUT DELETE TRACE OPTIONS; do


### PR DESCRIPTION
Due to Xcode IDE having become a standalone application, iPhone Simulator.app:
- is no longer available in Safari’s Develop menu,
- isn’t indexed by and can’t be launched using Spotlight,
- can’t be added to Launchpad.

The alias is just a more convenient trigger.
