### PR TITLE
.aliases Add `pdf-concat` alias that merges pdf files

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -95,6 +95,9 @@ alias showdesktop="defaults write com.apple.finder CreateDesktop -bool true && k
 # URL-encode strings
 alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1]);"'
 
+# Merge PDF files. Usage pdf-concat -o output.pdf input{1,2,3}.pdf
+alias pdf-concat='/System/Library/Automator/Combine\ PDF\ Pages.action/Contents/Resources/join.py'
+
 # Disable Spotlight
 alias spotoff="sudo mdutil -a -i off"
 # Enable Spotlight


### PR DESCRIPTION
Credit goes to Fritz Stelluto and his article on his blog
http://blog.gotofritz.net/howto/joining-pdf-files-in-os-x-from-the-command-line/
