### PR TITLE
Rename function md() to mkd()

### DIFF
--- a/.functions
+++ b/.functions
@@ -1,5 +1,5 @@
 # Create a new directory and enter it
-function md() {
+function mkd() {
 	mkdir -p "$@" && cd "$@"
 }
 


### PR DESCRIPTION
Rename function `md()` to `mkd()`, cause Mac OS X [use](http://developer.apple.com/library/mac/#documentation/Darwin/Reference/Manpages/man1/md.1.html) `md` command.
