### PR TITLE
.bash_profile: Fix completion for killall command with new OS X 10.8 names

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -34,7 +34,8 @@ export LANG="en_US"
 complete -W "NSGlobalDomain" defaults
 
 # Add `killall` tab completion for common apps
-complete -o "nospace" -W "Finder Dock Mail Safari iTunes iCal Address\ Book SystemUIServer" killall
+complete -o "nospace" -W "Address Book Contacts iCal Calendar Dock Finder Mail \
+    Safari iTunes SystemUIServer Terminal Twitter" killall
 
 # If possible, add tab completion for many more commands
 [ -f /etc/bash_completion ] && source /etc/bash_completion


### PR DESCRIPTION
Added new names for `killall` tabcompletion.
