### PR TITLE
Prevent Safari from opening "safe" files automatically after downloading

### DIFF
--- a/.osx
+++ b/.osx
@@ -337,6 +337,9 @@ defaults write com.apple.dock wvous-bl-modifier -int 0
 # Set Safari’s home page to `about:blank` for faster loading
 defaults write com.apple.Safari HomePage -string "about:blank"
 
+# Prevent Safari from opening "safe" files automatically after downloading
+defaults write com.apple.Safari AutoOpenSafeDownloads -bool false
+
 # Allow hitting the Backspace key to go to the previous page in history
 defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2BackspaceKeyNavigationEnabled -bool true
 


### PR DESCRIPTION
The default behaviour of automatically opening "safe" files is not only annoying but potentially a security threat - I can't think of any reason why a serious user would want it left on.
