### PR TITLE
Fixed 'flush' alias to work with OSX 10.7 & 10.8

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -53,7 +53,7 @@ alias ips="ifconfig -a | grep -o 'inet6\? \(\([0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+
 alias whois="whois -h whois-servers.net"
 
 # Flush Directory Service cache
-alias flush="dscacheutil -flushcache"
+alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
 
 # Clean up LaunchServices to remove duplicates in the “Open With” menu
 alias lscleanup="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain system -domain user && killall Finder"


### PR DESCRIPTION
The 'flush' alias is out-of-date. Starting in OS X Lion (10.7), it is necessary not only to use the old `dscacheutil -flushcache`, but also to use `killall -HUP mDNSResponder`. Apple explains this change in [this support article](http://support.apple.com/kb/HT5343). This change applies to Mountain Lion (10.8) as well as Lion. 
