### PR TITLE
.brew: Install PHP’s dependencies first

### DIFF
--- a/.brew
+++ b/.brew
@@ -26,6 +26,9 @@ brew install narwhal
 brew tap homebrew/dupes
 brew install homebrew/dupes/grep
 brew tap josegonzalez/homebrew-php
+# Install PHP’s dependencies first: `libpng` and `freetype`
+brew install libpng
+brew install freetype
 brew install php54
 
 # These two formulae didn’t work well last time I tried them:


### PR DESCRIPTION
It looks like [`php54` is dependent on `libpng` and `freetype`](https://github.com/josegonzalez/homebrew-php/issues/235#issuecomment-8033509). Before [they make to the official formula](https://github.com/josegonzalez/homebrew-php/pull/236), it’s safe to manually install these dependencies before `php54`.
