### PR TITLE
.gitconfig: Tweak `diff` aliases

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -4,7 +4,8 @@
 	# View the current working tree status using the short format
 	s = status -s
 	# Diff
-	d = diff --patch-with-stat
+	d = !"git diff-index --quiet HEAD -- || clear; git diff --patch-with-stat"
+	di = !"d() { git diff --patch-with-stat HEAD~$1; }; git diff-index --quiet HEAD -- || clear; d"
 	# Pull in remote changes for the current repository and all its submodules
 	p = !"git pull; git submodule foreach git pull origin master"
 	# Clone a repository including all submodules


### PR DESCRIPTION
`git d`/`di` will `clear` the screen before displaying `git diff` unless it’s empty.

`git di [$number]` displays `diff` between the current state and the given number of previous revisions (I’m unable put it in words properly, hehe).
