### PR TITLE
Correct symlink for iPhone Simulator.app

### DIFF
--- a/.osx
+++ b/.osx
@@ -317,8 +317,8 @@ defaults write com.apple.dock showhidden -bool true
 # Reset Launchpad
 find ~/Library/Application\ Support/Dock -name "*.db" -maxdepth 1 -delete
 
-# Add iPhone Simulator.app to Launchpad
-ln -s /Applications/Xcode.app/Contents/Applications/iPhone\ Simulator.app /Applications/iPhone\ Simulator.app
+# Add iPhone Simulator.app to Launchpad and /Applications
+ln -s /Applications/Xcode.app/Contents/Applications/iPhone\ Simulator.app /Applications/iOS\ Simulator.app
 
 # Add a spacer to the left side of the Dock (where the applications are)
 #defaults write com.apple.dock persistent-apps -array-add '{tile-data={}; tile-type="spacer-tile";}'


### PR DESCRIPTION
The existing symlink pointed the app to ~/Applications, which created a symlink in ~/ called Applications, but was really the iPhone Simulator. This line fixes that.
