### PR TITLE
Removing Dashboard

### DIFF
--- a/.osx
+++ b/.osx
@@ -300,6 +300,9 @@ defaults write com.apple.dock expose-group-by-app -bool false
 # Don’t show Dashboard as a Space
 defaults write com.apple.dock dashboard-in-overlay -bool true
 
+# Don't show Dashboard
+defaults write com.apple.dashboard mcx-disabled -bool true
+
 # Remove the auto-hiding Dock delay
 defaults write com.apple.Dock autohide-delay -float 0
 # Remove the animation when hiding/showing the Dock


### PR DESCRIPTION
I'm not a fan of the dashboard. I don't use any of the features, and I find it gets in my way when I'm traversing my desktops. With that in mind, I found a way to remove it. I hope you find this useful.
