### PR TITLE
Adding colored status indicator to branches.

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -133,5 +133,5 @@ function get_branch_name() {
 	fi
 	echo ""
 }
-export PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\h \[$WHITE\]in \[$PURPLE\]\w\$(get_branch_name)\n\[$RESET\]\$ "
+export PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\H \[$WHITE\]in \[$PURPLE\]\w\$(get_branch_name)\n\[$RESET\]\$ "
 export PS2="\[$ORANGE\]→ \[$RESET\]"


### PR DESCRIPTION
Removed \* to indicate change, replaced by the following colours:
    Green:       Working copy is clean.
    Yellow:      Changes have been added, and need to be committed.
    Red/Magenta: Changed have been made, but not added.

Added the following 'Remote' indicators:
    [↑]: Your branch is ahead of remote.
    [↓]: Your branch is behind remote.
    [↕]: Your branch and remote have diverged.
