### PR TITLE
Added .extra to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Thumbs.db
 # Files that might appear on external disks
 .Spotlight-V100
 .Trashes
+
+# Ignore .extra file
+.extra


### PR DESCRIPTION
I could be wrong, but i think the `.extra` file should be in the `.gitignore` file?

I am editing my dotfiles in my project folder and it turns me down to have the `.extra` file outside of this folder (only exist in HOME)
