### PR TITLE
Prevent app icons from staying in the dock after closing

### DIFF
--- a/.osx
+++ b/.osx
@@ -287,6 +287,9 @@ defaults write com.apple.dock enable-spring-load-actions-on-all-items -bool true
 # Show indicator lights for open applications in the Dock
 defaults write com.apple.dock show-process-indicators -bool true
 
+# Prevent app icons from staying in the Dock after being closed
+defaults write com.apple.dock static-only -bool true
+
 # Wipe all (default) app icons from the Dock
 # This is only really useful when setting up a new Mac, or if you don’t use
 # the Dock to launch apps.


### PR DESCRIPTION
After the app is closed, the app icon will no longer hang around in the Dock.
