### PR TITLE
bootstrap.sh: cd back to previous directory after complete

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,3 +15,4 @@ else
 fi
 unset doIt
 source ~/.bash_profile
+cd $OLDPWD


### PR DESCRIPTION
`cd $OLDPWD` prevents echoing the directory we are cd'ing to, vs. `cd -`.

This is similar to the first commit from https://github.com/mathiasbynens/dotfiles/pull/26, and allows you to conveniently run the bootstrap from anywhere and continue what you were doing. I didn't experience any side effects running bootstrap from my dotfiles repo, and this works with and without `source`.
