### PR TITLE
.gitconfig: Add `m` alias to merge branches keeping historical existence of the merged branch

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -13,6 +13,8 @@
 	c = clone --recursive
 	# Commit all changes
 	ca = !git add -A && git commit -av
+	# Merge branches, keeping historical existence of the merged branch
+	m = merge --no-ff
 	# Switch to a branch, creating it if necessary
 	go = checkout -B
 	# Show verbose output about tags, branches or remotes


### PR DESCRIPTION
I often find myself not wanting to fast forward the merged branches and I think it could be an useful addition. 

More info about using the `--no-ff` flag from [A successful Git branching model](http://nvie.com/posts/a-successful-git-branching-model/) by @nvie

> The --no-ff flag causes the merge to always create a new commit object, even if the merge could be performed with a fast-forward. This avoids losing information about the historical existence of a feature branch and groups together all commits that together added the feature. Compare:
> 
> ![merge-without-ff](https://f.cloud.github.com/assets/192261/75390/8abd36e2-60c3-11e2-9fb8-d9af74762bfc.png)

Please, review.
