### PR TITLE
Adding tr to ssh autocomplete allows aliases. 

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -26,7 +26,7 @@ for option in autocd globstar; do
 done
 
 # Add tab completion for SSH hostnames based on ~/.ssh/config, ignoring wildcards
-[ -e "$HOME/.ssh/config" ] && complete -o "default" -o "nospace" -W "$(grep "^Host" ~/.ssh/config | grep -v "[?*]" | cut -d " " -f2)" scp sftp ssh
+[ -e "$HOME/.ssh/config" ] && complete -o "default" -o "nospace" -W "$(grep "^Host" ~/.ssh/config | grep -v "[?*]" | cut -d " " -f2 | tr ' ' '\012')" scp sftp ssh
 
 # Add tab completion for `defaults read|write NSGlobalDomain`
 # You could just use `-g` instead, but I like being explicit


### PR DESCRIPTION
ssh config allows for the usage of aliases that are addressed like so:
Host first_alias second_alias third_alias
HostName my.hostname.com

Adding the tr in the complete command parses these aliases out and adds them to the autocomplete list.
