### PR TITLE
Enabling assistive devices no longer requires GUI password

### DIFF
--- a/.osx
+++ b/.osx
@@ -121,10 +121,7 @@ defaults write com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int
 defaults write NSGlobalDomain AppleKeyboardUIMode -int 3
 
 # Enable access for assistive devices
-echo -n 'a' | sudo tee /private/var/db/.AccessibilityAPIEnabled > /dev/null 2>&1
-sudo chmod 444 /private/var/db/.AccessibilityAPIEnabled
-# TODO: avoid GUI password prompt somehow (http://apple.stackexchange.com/q/60476/4408)
-#sudo osascript -e 'tell application "System Events" to set UI elements enabled to true'
+sudo touch /private/var/db/.AccessibilityAPIEnabled
 
 # Use scroll gesture with the Ctrl (^) modifier key to zoom
 defaults write com.apple.universalaccess closeViewScrollWheelToggle -bool true


### PR DESCRIPTION
Changed the code so it no longer needs the GUI password prompt.
Code taken from http://hints.macworld.com/article.php?story=20060203225241914
