### PR TITLE
osx: fix language settings comment to include en_US

### DIFF
--- a/.osx
+++ b/.osx
@@ -145,7 +145,7 @@ defaults write com.apple.BezelServices kDimTime -int 300
 
 # Set language and text formats
 # Note: if you’re in the US, replace `EUR` with `USD`, `Centimeters` with
-# `Inches`, and `true` with `false`.
+# `Inches`, `en_GB` with `en_US`, and `true` with `false`.
 defaults write NSGlobalDomain AppleLanguages -array "en" "nl"
 defaults write NSGlobalDomain AppleLocale -string "en_GB@currency=EUR"
 defaults write NSGlobalDomain AppleMeasurementUnits -string "Centimeters"


### PR DESCRIPTION
In the comment that tells US users what to change, there is one missing item.  I missed it and OSX kept changing my current region setting to UK whenever I restarted my computer
