### PR TITLE
Add method to make it easier to install grunt tasks

### DIFF
--- a/.functions
+++ b/.functions
@@ -163,3 +163,10 @@ function unquarantine() {
 		xattr -r -d "$attribute" "$@"
 	done
 }
+
+# Install grunt tasks and add to package.json
+# Usage: gi sass contrib-uglify
+function gi() {
+	local IFS=,
+	eval npm install --save-dev grunt-{"$*"}
+}


### PR DESCRIPTION
Only tested on ZSH

Grunt is getting popular these days, but it's a chore having to install a multitude of tasks on each project. This makes it a tiny bit easier.
