### PR TITLE
anti-spotlight

### DIFF
--- a/.osx
+++ b/.osx
@@ -575,6 +575,14 @@ defaults write com.twitter.twitter-mac ShowFullNames -bool true
 defaults write com.twitter.twitter-mac HideInBackground -bool true
 
 ###############################################################################
+# Spotlight                                                                   #
+###############################################################################
+
+# Stop Spotlight from indexing computer (good for if you use other launcher like Quicksilver or Alfred').
+# Can be turned back on again with `on` instead of `off`
+sudo mdutil -a -i off
+
+###############################################################################
 # Kill affected applications                                                  #
 ###############################################################################
 


### PR DESCRIPTION
spotlight slows down computer when indexing. No point if you don't use it, and most powerusers don't.
