### PR TITLE
git autocompletion for 'g' as well

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -20,6 +20,9 @@ alias s="subl ."
 alias o="open"
 alias oo="open ."
 
+# Enable git command  autocompletion for 'g' as well
+complete -o default -o nospace -F _git g
+
 # Detect which `ls` flavor is in use
 if ls --color > /dev/null 2>&1; then # GNU `ls`
 	colorflag="--color"


### PR DESCRIPTION
Add a line to .aliases to enable git command  autocompletion for the 'g' shortcut as well. This gives tab-autocompletion for stuff like "g st<tab>".

I'm not sure if .aliases is exactly the right place, but I put it here because it's close to the definition of the 'g' shortcut.
