### PR TITLE
.functions: Improve `targz`

### DIFF
--- a/.brew
+++ b/.brew
@@ -39,10 +39,12 @@ brew install git
 #brew install imagemagick
 brew install lynx
 brew install node
+brew install pigz
 brew install rename
 brew install rhino
 brew install tree
 brew install webkit2png
+brew install zopfli
 
 brew tap homebrew/versions
 brew install lua52

--- a/.functions
+++ b/.functions
@@ -26,18 +26,32 @@ function cdf() { # short for `cdfinder`
 	cd "$(osascript -e 'tell app "Finder" to POSIX path of (insertion location as alias)')"
 }
 
-# Create a .tar.gz archive, using `zopfli` or `gzip` for compression
+# Create a .tar.gz archive, using `zopfli`, `pigz` or `gzip` for compression
 function targz() {
-	if zopfli > /dev/null 2>&1; then
+	local tmpFile="${@}.tar"
+	tar -cvf "${tmpFile}" --exclude=".DS_Store" "${@}" || return 1
+
+	size=$(
+		stat -f"%z" "${tmpFile}" 2> /dev/null; # OS X `stat`
+		stat -c"%s" "${tmpFile}" 2> /dev/null # GNU `stat`
+	)
+
+	local cmd=""
+	if (( size < 52428800 )) && hash zopfli 2> /dev/null; then
+		# the .tar file is smaller than 50 MB and Zopfli is available; use it
 		cmd="zopfli"
 	else
-		cmd="gzip"
+		if hash pigz 2> /dev/null; then
+			cmd="pigz"
+		else
+			cmd="gzip"
+		fi
 	fi
-	local tmpFile="${1}.tar"
-	tar -cvf "${tmpFile}" "${1}" &&
-	"${cmd}" "${tmpFile}" &&
-	rm "${tmpFile}" 2> /dev/null &&
-	echo "${tmpFile}.gz created successfully (compressed using \`${cmd}\`)."
+
+	echo "Compressing .tar using \`${cmd}\`…"
+	"${cmd}" -v "${tmpFile}" || return 1
+	[ -f "${tmpFile}" ] && rm "${tmpFile}"
+	echo "${tmpFile}.gz created successfully."
 }
 
 # Determine size of a file or total size of a directory


### PR DESCRIPTION
Idea: Would be cool if `targz foo` would create `foo.tar`, then check its file size, and then use it to decide wether to use `zopfli` or `gzip`. Anything over, say, 50 MB, should probably use gzip. Zopfli is great for small files, but quickly becomes too slow as file size increases.

@alrra suggested using fewer Zopfli iterations (`15` is the default) but I’m not sure about that, as it would minimize the benefit of using Zopfli.

@einars suggested using [pigz](http://zlib.net/pigz/) (`brew install pigz`), the fast gzip-compatible multithreaded compressor™. Perhaps another check before falling back to `gzip`?
