### PR TITLE
trim last slash on 'targz' argument

### DIFF
--- a/.functions
+++ b/.functions
@@ -28,7 +28,7 @@ function cdf() { # short for `cdfinder`
 
 # Create a .tar.gz archive, using `zopfli`, `pigz` or `gzip` for compression
 function targz() {
-	local tmpFile="${@}.tar"
+	local tmpFile="${@%/}.tar"
 	tar -cvf "${tmpFile}" --exclude=".DS_Store" "${@}" || return 1
 
 	size=$(


### PR DESCRIPTION
Currently, if we use 'targz dirname/' 
it will create a filename called '.tar.gz' in the directory 'dirname'
this change removes the last slash from the argument
