### PR TITLE
bootstrap.sh bug: if bootstrap pulls a new bootstrap, syncing continues with old bootstrap -> bad things happen

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ NEW_BOOTSTRAP=$(md5sum $SCRIPTNAME)
 
 if [ ! "$CURRENT_BOOTSTRAP" = "$NEW_BOOTSTRAP" ]; then
     echo "$SCRIPTNAME has changed. Please run the script again."
-    exit 0
+    return 0
 fi
 
 


### PR DESCRIPTION
Previously, if bootstrap.sh had been changed in the origin repo,
the syncing would continue using the old bootstrap.sh. This can
cause problems such as the following: Say you have added a new
LICENSE file and an appropriate exclusion in the rsync of bootstraph.sh.
When a user does `source bootstrap.sh` the new LICENSE file and
bootstrap.sh file get pulled but the syncing continues with the old
bootstrap which doesn't have the exclusion, thus giving you a LICENSE
file in your ~. This commit gives a basic solution of exiting if the
bootstrap.sh file has changed after the `git pull`.

> Ideally, this could be automated because there isn't any real reason the user should be bothered. I just wasn't sure how to implement it.  

I have [an idea](https://github.com/mathiasbynens/dotfiles/pull/206#discussion_r4363492).
