### PR TITLE
Removed global remote branch in .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -55,11 +55,6 @@
 	# Include summaries of merged commits in newly created merge commit messages
 	log = true
 
-# Use `origin` as the default remote on the `master` branch in all cases
-[branch "master"]
-	remote = origin
-	merge = refs/heads/master
-
 # URL shorthands
 [url "git@github.com:"]
 	insteadOf = "gh:"


### PR DESCRIPTION
This causes duplicate remotes to be created and git starts throwing errors when you try to push. Confirmed in #github
