### PR TITLE
bootstrap.sh: moved `source` command into doIt()

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,8 @@ function doIt() {
 	rsync --exclude ".git/" --exclude ".DS_Store" --exclude "bootstrap.sh" \
 		--exclude "README.md" --exclude "LICENSE-GPL.txt" \
 		--exclude "LICENSE-MIT.txt" -av --no-perms . ~
+
+	source ~/.bash_profile
 }
 if [ "$1" == "--force" -o "$1" == "-f" ]; then
 	doIt
@@ -16,4 +18,3 @@ else
 	fi
 fi
 unset doIt
-source ~/.bash_profile


### PR DESCRIPTION
No reason to source the files if there aren't
going to be any changes.
