### PR TITLE
Change the link for forking to match GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 git config --global user.email "$GIT_AUTHOR_EMAIL"
 ```
 
-You could also use `~/.extra` to override settings, functions and aliases from my dotfiles repository. It’s probably better to [fork this repository](https://github.com/mathiasbynens/dotfiles/fork_select) instead, though.
+You could also use `~/.extra` to override settings, functions and aliases from my dotfiles repository. It’s probably better to [fork this repository](https://github.com/mathiasbynens/dotfiles/fork) instead, though.
 
 ### Sensible OS X defaults
 


### PR DESCRIPTION
Seems GitHub quietly changed this URL on us.
