### PR TITLE
Update .bash_prompt

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -44,7 +44,7 @@ export BOLD
 export RESET
 
 function parse_git_dirty() {
-	[[ $(git status 2> /dev/null | tail -n1) != *"working directory clean"* ]] && echo "*"
+	[[ $(git status --porcelain 2> /dev/null | tail -n1) != "" ]] && echo "*"
 }
 
 function parse_git_branch() {


### PR DESCRIPTION
I'm on git version 1.8.3.2 and the existing check failed for me, always showing up the \* even on clean branch.
