### PR TITLE
bin/subl points to correct Sublime Text executable

### DIFF
--- a/bin/subl
+++ b/bin/subl
@@ -1,1 +1,1 @@
-/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl
+/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl


### PR DESCRIPTION
Sublime Text 3 does not use the `/Application/Sublime Text 3.app` folder by default.

It uses `/Application/Sublime Text.app`.
