### PR TITLE
Add a slash to directories when listing

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -28,13 +28,13 @@ else # OS X `ls`
 fi
 
 # List all files colorized in long format
-alias l="ls -l ${colorflag}"
+alias l="ls -lF ${colorflag}"
 
 # List all files colorized in long format, including dot files
-alias la="ls -la ${colorflag}"
+alias la="ls -laF ${colorflag}"
 
 # List only directories
-alias lsd='ls -l ${colorflag} | grep "^d"'
+alias lsd='ls -lF ${colorflag} | grep "^d"'
 
 # Always use color output for `ls`
 alias ls="command ls ${colorflag}"


### PR DESCRIPTION
Having a slash after a directory name is yelling _DIRECTORY_ for decades.

That's why I really like the `-F` flag.

It has other useful features as well.

From the `ls` manual:

> Display a slash (`/`) immediately after each pathname that is a directory, an asterisk (`*`) after each that is executable, an at sign (`@`) after each symbolic link, an equals sign (`=`) after each socket, a percent sign (`%`) after each whiteout, and a vertical bar (`|`) after each that is a FIFO.
