### PR TITLE
Alias to kill all the tabs in Chrome to free up memory

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -139,3 +139,7 @@ command -v grunt > /dev/null && alias grunt="grunt --stack"
 alias stfu="osascript -e 'set volume output muted true'"
 alias pumpitup="osascript -e 'set volume 7'"
 alias hax="growlnotify -a 'Activity Monitor' 'System error' -m 'WTF R U DOIN'"
+
+# Kill all the tabs in Chrome to free up memory
+# [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
+alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"


### PR DESCRIPTION
Useful when you have a lot of tabs open (which I always do), but you don't want to close them.

Tabs in Chrome are just processes, so we just filter out the ones we want, and kill them.
