### PR TITLE
gitio outputs only the needed short url

### DIFF
--- a/.functions
+++ b/.functions
@@ -91,7 +91,7 @@ function gitio() {
 		echo "Usage: \`gitio slug url\`"
 		return 1
 	fi
-	curl -i http://git.io/ -F "url=${2}" -F "code=${1}"
+	curl --silent --include http://git.io/ --form "url=${2}" --form "code=${1}" | grep "Location: " | awk '{print $2}'
 }
 
 # Start an HTTP server from a directory, optionally specifying the port


### PR DESCRIPTION
Instead of outputting the headers of the request we could just extract the needed Location header.

I have expanded the cURL flags to their long form for readability (short-form command-line arguments should be used only on the command line).

---

BTW, we could use the `http://git.io/create endpoint directly which returns the slug in the body of the response.
However we would not be able to provide a desired slug then.
