### PR TITLE
o with no arguments opens current directory

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -17,8 +17,6 @@ alias j="jobs"
 alias v="vim"
 alias m="mate ."
 alias s="subl ."
-alias o="open"
-alias oo="open ."
 
 # Detect which `ls` flavor is in use
 if ls --color > /dev/null 2>&1; then # GNU `ls`

--- a/.functions
+++ b/.functions
@@ -251,3 +251,12 @@ function gi() {
 	local IFS=,
 	eval npm install --save-dev grunt-{"$*"}
 }
+
+# o with no arguments opens current directory, otherwise opens given location
+function o() {
+	if [ $# -eq 0 ]; then
+		open .
+	else
+		open "$@"
+	fi
+}


### PR DESCRIPTION
Replace `o` and `oo` open aliases with multi-purpose function. `o` with no arguments just opens the current directory. If any arguments are given, then that location will be used instead. I realize this is a big change and a little bit of a new way of thinking but I have been using this for a while now and it's quite nice. Saving keystrokes here. Got this idea from [@thoughbot/dotfiles](https://github.com/thoughtbot/dotfiles) `g` function.
