### PR TITLE
Add alias to reload the current shell (invoke as login shell)

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -143,3 +143,6 @@ alias hax="growlnotify -a 'Activity Monitor' 'System error' -m 'WTF R U DOIN'"
 # Kill all the tabs in Chrome to free up memory
 # [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
 alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"
+
+# Reload shell
+alias reload="exec $SHELL -l"


### PR DESCRIPTION
Convenient alias to reload the shell (invoke as a login shell, essentially reloading).
