### PR TITLE
. with no arguments traverses up directory, otherwise acts as `.`

### DIFF
--- a/.functions
+++ b/.functions
@@ -252,10 +252,10 @@ function gi() {
 	eval npm install --save-dev grunt-{"$*"}
 }
 
-# . with no arguments traverses up directory, otherwise acts as `.`
+# `.` with no arguments traverses up directory, otherwise acts as `.`
 function .() {
 	if [ $# -eq 0 ]; then
-		..
+		cd ..
 	else
 		. "$@"
 	fi


### PR DESCRIPTION
Another keystroke saver. `.` normally as a dual-purpose function now. Given its similarity to `..` and `...` and `....`, I shortcut just `.` with no arguments to act as `cd ..`. This should not affect anyone's normal workflow but just add extra functionality to `.` and save at least one keystroke.
