### PR TITLE
Check if it' s a file then source it. (.bash_profile)

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -5,7 +5,7 @@ export PATH="$HOME/bin:$PATH"
 # * ~/.path can be used to extend `$PATH`.
 # * ~/.extra can be used for other settings you don’t want to commit.
 for file in ~/.{path,bash_prompt,exports,aliases,functions,extra}; do
-	[ -r "$file" ] && source "$file"
+	[ -r "$file" ] && [ -f "$file" ] && source "$file"
 done
 unset file
 


### PR DESCRIPTION
If e.g. `~/.extra` is a directory this file throws an error.
This commit fixes this and only tries to source real files, not directorys.
