### PR TITLE
`s` with no arguments opens the current directory in Sublime

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -16,7 +16,6 @@ alias h="history"
 alias j="jobs"
 alias v="vim"
 alias m="mate ."
-alias s="subl ."
 alias o="open"
 alias oo="open ."
 

--- a/.functions
+++ b/.functions
@@ -251,3 +251,13 @@ function gi() {
 	local IFS=,
 	eval npm install --save-dev grunt-{"$*"}
 }
+
+# `s` with no arguments opens the current directory in Sublime, otherwise opens
+# the given location
+function s() {
+	if [ $# -eq 0 ]; then
+		subl .
+	else
+		subl "$@"
+	fi
+}


### PR DESCRIPTION
`s` with no arguments opens the current directory in Sublime, otherwise opens the given location. I think the current `s` alias is inconsistent given that it specifically opens the current directory. But if I want to open just a given file or directory then I have to use `subl mydir`. This function handles both cases and brings consistency with all editor choices.
