### PR TITLE
Remove tilde alias

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,9 +1,8 @@
-# Easier navigation: .., ..., ...., ....., ~ and -
+# Easier navigation: .., ..., ...., ..... and -
 alias ..="cd .."
 alias ...="cd ../.."
 alias ....="cd ../../.."
 alias .....="cd ../../../.."
-alias ~="cd ~" # `cd` is probably faster to type though
 alias -- -="cd -"
 
 # Shortcuts


### PR DESCRIPTION
I think the comment says it all here. Why not clean it up if it's not used?
