### PR TITLE
simplify ip address lookup

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -53,7 +53,7 @@ alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
 alias localip="ipconfig getifaddr en1"
-alias ips="ifconfig -a  | awk '/inet /{print $2}'"
+alias ips="ifconfig -a  | awk '/inet/{print $2}'"
 
 # Enhanced WHOIS lookups
 alias whois="whois -h whois-servers.net"


### PR DESCRIPTION
identical output, just simpler to grok.

Doesn't work as well on my ubuntu, but the current lookup doesn't work at all, and it's IP address never changes anyway.
