### PR TITLE
Remove "Dashboard" from the `Kill affected applications` section

### DIFF
--- a/.osx
+++ b/.osx
@@ -659,7 +659,7 @@ defaults write com.twitter.twitter-mac HideInBackground -bool true
 # Kill affected applications                                                  #
 ###############################################################################
 
-for app in "Address Book" "Calendar" "Contacts" "Dashboard" "Dock" "Finder" \
+for app in "Address Book" "Calendar" "Contacts" "Dock" "Finder" \
 	"Mail" "Messages" "Safari" "SizeUp" "SystemUIServer" "Terminal" \
 	"Transmission" "Twitter" "iCal"; do
 	killall "${app}" > /dev/null 2>&1


### PR DESCRIPTION
`killall Dashboard` doesn't actually do anything. To apply the changes for Dashboard, `killall Dock` is enough as Dock is Dashboard's parent process.

![screen shot 2013-11-03 at 12 56 03 am](https://f.cloud.github.com/assets/1223565/1460135/275a03a8-4413-11e3-89dc-8ff98ebc8265.png)
