### PR TITLE
Excluding the homebrew Brewfile from syncing

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,8 @@ cd "$(dirname "${BASH_SOURCE}")"
 git pull origin master
 function doIt() {
 	rsync --exclude ".git/" --exclude ".DS_Store" --exclude "bootstrap.sh" \
-		--exclude "README.md" --exclude "LICENSE-MIT.txt" -av --no-perms . ~
+		--exclude "README.md" --exclude "LICENSE-MIT.txt" \
+		--exclude "Brewfile" -av --no-perms . ~
 	source ~/.bash_profile
 }
 if [ "$1" == "--force" -o "$1" == "-f" ]; then


### PR DESCRIPTION
Just a small change but I think it doesn't make sense to sync the Brewfile with the home directory.
