### PR TITLE
.osx: Hide Safari's Sidebar in Top Sites by default.

### DIFF
--- a/.osx
+++ b/.osx
@@ -425,6 +425,9 @@ defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebK
 # Hide Safari’s bookmarks bar by default
 defaults write com.apple.Safari ShowFavoritesBar -bool false
 
+# Hide Safari's Sidebar in Top Sites.
+defaults write com.apple.Safari ShowSidebarInTopSites -bool false
+
 # Disable Safari’s thumbnail cache for History and Top Sites
 defaults write com.apple.Safari DebugSnapshotsUpdatePolicy -int 2
 


### PR DESCRIPTION
This makes Sidebar hidden by default in Top Sites.
