### PR TITLE
Add ability to use symlink.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Here’s an example `~/.path` file that adds `~/utils` to the `$PATH`:
 export PATH="$HOME/utils:$PATH"
 ```
 
+### Link instead of copy files
+
+```$ bootstrap -l```
+
+or using ```source```
+
+```bash
+set -- -l; source bootstrap.sh
+```
+
 ### Add custom commands without creating a new fork
 
 If `~/.extra` exists, it will be sourced along with the other files. You can use this to add a few custom commands without the need to fork this entire repository, or to add commands you don’t want to commit to a public repository.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,18 +1,46 @@
 #!/usr/bin/env bash
+OPTIND=1
+
 cd "$(dirname "${BASH_SOURCE}")"
 git pull origin master
 function doIt() {
 	rsync --exclude ".git/" --exclude ".DS_Store" --exclude "bootstrap.sh" \
 		--exclude "README.md" --exclude "LICENSE-MIT.txt" -av --no-perms . ~
-	source ~/.bash_profile
 }
-if [ "$1" == "--force" -o "$1" == "-f" ]; then
-	doIt
+function linkIt() {
+	FILES=$(find . -type f -maxdepth 1 -name ".*" -not -name .DS_Store -not -name .git -not -name .osx | sed -e 's|//|/|' | sed -e 's|./.|.|')
+  	for file in $FILES; do 
+		ln -sf $(dirname "${BASH_SOURCE}")/${file} ~/${file}
+	done	
+}
+
+while getopts "fl" opt; do
+	case "$opt" in
+		f)
+			FORCE=1
+			;;
+		l)
+			LINK=1
+			;;
+	esac
+done
+
+if [ "$FORCE" == "1" ]; then
+	if [ "$LINK" == "1" ]; then
+		linkIt
+	else
+		doIt
+	fi
 else
 	read -p "This may overwrite existing files in your home directory. Are you sure? (y/n) " -n 1
 	echo
 	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		doIt
+		if [ "$LINK" == "1" ]; then
+			linkIt
+		else
+			doIt
+		fi
 	fi
 fi
+source ~/.bash_profile
 unset doIt


### PR DESCRIPTION
Might not be desired, but I don't want to copy the dotfiles, I want to link them. This was mainly a hack for me and a bunch of friends who like this repo, but want to link instead of copy.

Issue: Kills the `--force` full name flag because I don't flesh out the `getopts` call.
