### PR TITLE
Add a block for default right-click behavior.

### DIFF
--- a/.osx
+++ b/.osx
@@ -147,6 +147,10 @@ defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadRightC
 defaults -currentHost write NSGlobalDomain com.apple.trackpad.trackpadCornerClickBehavior -int 1
 defaults -currentHost write NSGlobalDomain com.apple.trackpad.enableSecondaryClick -bool true
 
+# Trackpad: right-click by tapping with two fingers
+#defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadRightClick -bool true
+#defaults -currentHost write NSGlobalDomain com.apple.trackpad.enableSecondaryClick -bool true
+
 # Disable “natural” (Lion-style) scrolling
 defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false
 


### PR DESCRIPTION
I don’t know if you would like to have options you are not using in your dotfiles. Maybe it’s an advantage for people who are forking your famous dotfile repository (like me).

So this is more like a »just in case« pull request :smirk:
Take it or leave it …

Howerever I would like to thank you for sharing your mighty dotfiles.
