### PR TITLE
np() - remove `node_modules` before testing for a release

### DIFF
--- a/.functions
+++ b/.functions
@@ -296,6 +296,7 @@ function o() {
 # defaults to `patch`
 function np() {
 	git pull --rebase && \
+	rm -rf node_modules && \
 	npm install && \
 	npm test && \
 	npm version ${1:=patch} && \


### PR DESCRIPTION
This lets you catch cases where you forgot to add a dependency to package.json
