### PR TITLE
Only add custom terminal profile once.

### DIFF
--- a/.osx
+++ b/.osx
@@ -537,10 +537,10 @@ defaults write com.apple.terminal StringEncodings -array 4
 TERM_PROFILE="Mathias"
 CURRENT_PROFILE=$(defaults read com.apple.terminal "Default Window Settings")
 if [ $CURRENT_PROFILE != $TERM_PROFILE ]; then
-    open "${HOME}/init/${TERM_PROFILE_NAME}.terminal"
+    open "${HOME}/init/${TERM_PROFILE}.terminal"
     sleep 1 # Wait a bit to make sure the theme is loaded
-    defaults write com.apple.terminal "Default Window Settings" -string "${TERM_PROFILE_NAME}"
-    defaults write com.apple.terminal "Startup Window Settings" -string "${TERM_PROFILE_NAME}"
+    defaults write com.apple.terminal "Default Window Settings" -string "${TERM_PROFILE}"
+    defaults write com.apple.terminal "Startup Window Settings" -string "${TERM_PROFILE}"
 fi
 
 # Enable “focus follows mouse” for Terminal.app and all X11 apps


### PR DESCRIPTION
This will check if the terminal profile is already set before adding it. Otherwise, duplicate profiles will be added each time `.osx` is run.
