### PR TITLE
.osx: Make `Dock` more transparent

### DIFF
--- a/.osx
+++ b/.osx
@@ -394,6 +394,9 @@ defaults write com.apple.dock autohide -bool true
 # Make Dock icons of hidden applications translucent
 defaults write com.apple.dock showhidden -bool true
 
+# Make Dock more transparent
+defaults write com.apple.dock hide-mirror -bool true
+
 # Reset Launchpad
 find ~/Library/Application\ Support/Dock -name "*.db" -maxdepth 1 -delete
 


### PR DESCRIPTION
![](https://f.cloud.github.com/assets/1223565/2302496/fb96a016-a180-11e3-9a6a-6d3493a9e87b.png)
## 

Works with OS X 10.9+ 
