### PR TITLE
.osx: Fix problem with setting the Terminal theme

### DIFF
--- a/.osx
+++ b/.osx
@@ -537,10 +537,11 @@ sudo mdutil -E / > /dev/null
 defaults write com.apple.terminal StringEncodings -array 4
 
 # Use a modified version of the Pro theme by default in Terminal.app
-open "${HOME}/init/Mathias.terminal"
-sleep 1 # Wait a bit to make sure the theme is loaded
-defaults write com.apple.terminal "Default Window Settings" -string "Mathias"
-defaults write com.apple.terminal "Startup Window Settings" -string "Mathias"
+open "${BASH_SOURCE%/*}/Mathias.terminal"
+#       └─ see: http://mywiki.wooledge.org/BashFAQ/028
+defaults write com.apple.Terminal "Default Window Settings" -string "Mathias"
+defaults write com.apple.Terminal "Startup Window Settings" -string "Mathias"
+defaults import com.apple.Terminal "$HOME/Library/Preferences/com.apple.Terminal.plist"
 
 # Enable “focus follows mouse” for Terminal.app and all X11 apps
 # i.e. hover over a window and start typing in it without clicking first


### PR DESCRIPTION
- Terminal.app needs to be "informed" about the theme change, otherwise it will just overwrite the new settings.  (With the solution provided in this commit, the theme should be applied once the terminal is restarted).
- Assuming that the theme is right next to the `.osx` script, use `${BASH_SOURCE%/*`}, instead of the hard coded `${HOME}/init/`.

Ref: #185.

**edit:** Doesn't always work :(
