### PR TITLE
.cask: Add Opera, Opera Developer and Opera Next

### DIFF
--- a/.cask
+++ b/.cask
@@ -1,6 +1,6 @@
 # Install native apps
-brew tap phinze/homebrew-cask
-brew install brew-cask
+brew install phinze/cask/brew-cask
+brew tap caskroom/versions
 
 function installcask() {
 	brew cask install "${@}" 2> /dev/null
@@ -14,6 +14,9 @@ installcask imageoptim
 installcask iterm2
 installcask macvim
 installcask miro-video-converter
+installcask opera
+installcask opera-developer
+installcask opera-next
 installcask sublime-text
 installcask the-unarchiver
 installcask tor-browser


### PR DESCRIPTION
This patch also adds [`homebrew-cask-versions`](https://github.com/caskroom/homebrew-versions), which contains alternate versions of Casks (beta, dev and nightly releases).
