### PR TITLE
Added "a" command as alias for "atom"

### DIFF
--- a/.functions
+++ b/.functions
@@ -272,6 +272,16 @@ function s() {
 	fi
 }
 
+# `a` with no arguments opens the current directory in Atom Editor, otherwise
+# opens the given location
+function a() {
+	if [ $# -eq 0 ]; then
+		atom .
+	else
+		atom "$@"
+	fi
+}
+
 # `v` with no arguments opens the current directory in Vim, otherwise opens the
 # given location
 function v() {


### PR DESCRIPTION
I think this is a good addition, since Atom Editor has become quite popular within the last few days.

Cheers,

Christian
