### PR TITLE
.osx: Add missing value

### DIFF
--- a/.osx
+++ b/.osx
@@ -354,7 +354,7 @@ defaults write com.apple.dock show-process-indicators -bool true
 # Wipe all (default) app icons from the Dock
 # This is only really useful when setting up a new Mac, or if you don’t use
 # the Dock to launch apps.
-#defaults write com.apple.dock persistent-apps -array
+#defaults write com.apple.dock persistent-apps -array ""
 
 # Don’t animate opening applications from the Dock
 defaults write com.apple.dock launchanim -bool false


### PR DESCRIPTION
`defaults write com.apple.dock persistent-apps -array` doesn't work as `defaults` needs to be provided with a valid `value` for the `key`:

```
defaults write <domain> <key> <value>
```
