### PR TITLE
Don't treat indents with > 8 spaces as an error

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -47,7 +47,7 @@
 	# [default] trailing-space: looks for spaces at the end of a line
 	# [default] space-before-tab: looks for spaces before tabs at the beginning of
 	# a line
-	whitespace = space-before-tab,indent-with-non-tab,trailing-space
+	whitespace = space-before-tab,-indent-with-non-tab,trailing-space
 	# Make `git rebase` safer on OS X
 	# More info: <http://www.git-tower.com/blog/make-git-rebase-safe-on-osx/>
 	trustctime = false


### PR DESCRIPTION
Don't use `indent-with-non-tab`. This config flag is PERNICIOUS. If turned on, git won't tell you that you indented your code incorrectly. Instead, when it is pushing your changes to your remote repo, git will silently convert any consecutive 8-space strings it sees into tab characters. This can be highly undesirable, especially if you collaborate with a team that expects the code to be indented using spaces instead of tabs.

At the very least, the comment above this line should very clearly explain the fact that `indent-with-non-tab` does more than advertised in the [`git-config` man page](https://www.kernel.org/pub/software/scm/git/docs/git-config.html).
