### PR TITLE
.cask: Replace caskroom/versions tap with install path

### DIFF
--- a/.cask
+++ b/.cask
@@ -15,7 +15,7 @@ installcask macvim
 installcask miro-video-converter
 installcask opera
 installcask caskroom/versions/opera-developer
-installcask caskroom/versions/opera-next
+installcask opera-next
 installcask sublime-text
 installcask the-unarchiver
 installcask tor-browser


### PR DESCRIPTION
Let's do this more consistently, reference #348.
