### PR TITLE
.osx: Change minimize/maximize window effect

### DIFF
--- a/.osx
+++ b/.osx
@@ -342,6 +342,9 @@ defaults write com.apple.dock mouse-over-hilite-stack -bool true
 # Set the icon size of Dock items to 36 pixels
 defaults write com.apple.dock tilesize -int 36
 
+# Change minimize/maximize window effect
+defaults write com.apple.dock mineffect -string "scale"
+
 # Minimize windows into their application’s icon
 defaults write com.apple.dock minimize-to-application -bool true
 


### PR DESCRIPTION
By default, Mac OS X Mavericks, uses the annoying `genie` effect whenever windows are minimized/maximized. 

This commit changes that preference and makes OS X use the more tolerable `scale` effect.

Related issue: #270

---
- `genie` effect:

<img src="https://f.cloud.github.com/assets/1223565/2344097/50332d14-a51a-11e3-8f1c-9883b88f4dd8.gif" width="610px" height="440px">
- `scale` effect:

<img src="https://f.cloud.github.com/assets/1223565/2344101/7dbcdd84-a51a-11e3-9874-313333fa544b.gif" width="610px" height="440px">
