### PR TITLE
Adding npmls() function

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -52,7 +52,7 @@ alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup
 
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
-alias localip="ipconfig getifaddr en1"
+alias localip="ipconfig getifaddr en0"
 alias ips="ifconfig -a | grep -o 'inet6\? \(addr:\)\?\s\?\(\(\([0-9]\+\.\)\{3\}[0-9]\+\)\|[a-fA-F0-9:]\+\)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"
 
 # Enhanced WHOIS lookups

--- a/.osx
+++ b/.osx
@@ -398,7 +398,7 @@ defaults write com.apple.dock hide-mirror -bool true
 find ~/Library/Application\ Support/Dock -name "*.db" -maxdepth 1 -delete
 
 # Add iOS Simulator to Launchpad
-sudo ln -sf /Applications/Xcode.app/Contents/Applications/iPhone\ Simulator.app /Applications/iOS\ Simulator.app
+sudo ln -sf "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app" "/Applications/iOS Simulator.app"
 
 # Add a spacer to the left side of the Dock (where the applications are)
 #defaults write com.apple.dock persistent-apps -array-add '{tile-data={}; tile-type="spacer-tile";}'


### PR DESCRIPTION
Tired of seeing this...

```
$ npm ls -g
├─┬ anvil.js@0.9.0-RC3.1
│ ├── colors@0.6.0
│ ├─┬ commander@1.1.1
│ │ └── keypress@0.1.0
│ ├─┬ express@3.0.5
│ │ ├── buffer-crc32@0.1.1
│ │ ├── commander@0.6.1
│ │ ├─┬ connect@2.7.1
│ │ │ ├── bytes@0.1.0
│ │ │ ├── crc@0.2.0
│ │ │ ├── formidable@1.0.11
│ │ │ ├── pause@0.0.1
│ │ │ └── qs@0.5.1
│ │ ├── cookie@0.0.5
│ │ ├── cookie-signature@0.0.1
│ │ ├── debug@0.7.0
│ │ ├── fresh@0.1.0
│ │ ├── methods@0.0.1
│ │ ├── range-parser@0.0.4
│ │ └─┬ send@0.1.0
│ │   └── mime@1.2.6
│ ├─┬ fs-watch-tree@0.2.2
│ │ └── when@1.3.0
│ ├─┬ handlebars@1.0.7
│ │ ├─┬ optimist@0.3.5
│ │ │ └── wordwrap@0.0.2
│ │ └── uglify-js@1.2.6
...and more
```

Run npmls for a much cleaner output showing the top level packages only

```
├─┬ autoprefixer@1.1.20140302
├─┬ bower@1.3.1
├─┬ coffee-script@1.7.1
...and more
```
