### PR TITLE
Don't delete desktoppicture.db when resetting launchpad

### DIFF
--- a/.osx
+++ b/.osx
@@ -395,7 +395,7 @@ defaults write com.apple.dock showhidden -bool true
 defaults write com.apple.dock hide-mirror -bool true
 
 # Reset Launchpad
-find ~/Library/Application\ Support/Dock -name "*.db" -maxdepth 1 -delete
+find ~/Library/Application\ Support/Dock -name "*-*.db" -maxdepth 1 -delete
 
 # Add iOS Simulator to Launchpad
 sudo ln -sf "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app" "/Applications/iOS Simulator.app"


### PR DESCRIPTION
530142A0-6AEC-4921-A3A7-7C2B72FFF6E3.db and desktoppicture.db exist in ~/Library/Application\ Support/Dock, so I've added a '-' with a wildcard '*' to both sides to ensure we don't delete desktoppicture.db and reset the desktop wallpaper.
