### PR TITLE
Update phinze/cask to caskroom/cask.

### DIFF
--- a/Caskfile
+++ b/Caskfile
@@ -1,7 +1,7 @@
 # Install native apps
 # Usage: `brew bundle Caskfile`
 
-install phinze/cask/brew-cask
+install caskroom/cask/brew-cask
 tap caskroom/versions
 
 cask install dropbox 2> /dev/null


### PR DESCRIPTION
Homebrew Cask has now been moved to [caskroom/homebrew-cask](https://github.com/caskroom/homebrew-cask).
