### PR TITLE
Use grc to make bash less boring

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -4,7 +4,7 @@ export PATH="$HOME/bin:$PATH"
 # Load the shell dotfiles, and then some:
 # * ~/.path can be used to extend `$PATH`.
 # * ~/.extra can be used for other settings you don’t want to commit.
-for file in ~/.{path,bash_prompt,exports,aliases,functions,extra}; do
+for file in ~/.{path,bash_prompt,exports,aliases,functions,grc.bashrc,extra}; do
 	[ -r "$file" ] && [ -f "$file" ] && source "$file"
 done
 unset file

--- a/.grc.bashrc
+++ b/.grc.bashrc
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Bring colour to boring commands!
+GRC=$(which grc)
+if [ "$TERM" != dumb ] && [ -n "$GRC" ]
+then
+    alias colourify="$GRC -es --colour=auto"
+    alias configure='colourify ./configure'
+# `diff` is a shell function using `git-diff(1)`. See `.functions`.
+#   alias diff='colourify diff'
+    alias make='colourify make'
+    alias gcc='colourify gcc'
+    alias g++='colourify g++'
+    alias as='colourify as'
+    alias gas='colourify gas'
+    alias ld='colourify ld'
+    alias netstat='colourify netstat'
+    alias ping='colourify ping'
+    alias traceroute='colourify traceroute'
+fi

--- a/Brewfile
+++ b/Brewfile
@@ -40,6 +40,7 @@ install ack
 #install exiv2
 install foremost
 install git
+install grc
 install imagemagick --with-webp
 install lynx
 install nmap


### PR DESCRIPTION
[`grc` (Generic Colourizer)](http://korpus.juls.savba.sk/~garabik/software/grc.html) is a simple tool which brings colour to boring Bash commands.

Read the full [`grc` README](http://korpus.juls.savba.sk/~garabik/software/grc/README.txt).

Check out the [`grc` mirror repository on GitHub](https://github.com/pengwynn/grc).

I've done the following changes:
- Install `grc` via `brew`
- Copy `$(brew --prefix grc)/etc/grc.bashrc` to `~/.grc.bashrc`.
  `grc` colourize the `diff` command output by default. I've removed that
  since there already is a `diff()` function in `.functions` which uses `git`.
- Source the `grc.bashrc` file in `.bash_profile`.

Here is an example with colourless `ping` command:

**Pure `ping` using `/sbin/ping` without `colourify`**:

![Pure black & white `ping`](https://cloud.githubusercontent.com/assets/506129/2933046/ed6af81a-d7b9-11e3-8507-90f3dac6fffd.png)

**Fun `ping`**:

![Colourful IPs and ms in `ping`](https://cloud.githubusercontent.com/assets/506129/2933051/f6074492-d7b9-11e3-94e3-1ad82024a30c.png)
