### PR TITLE
Unhide /Users folder

### DIFF
--- a/.osx
+++ b/.osx
@@ -320,6 +320,9 @@ sudo nvram boot-args="mbasd=1"
 # Show the ~/Library folder
 chflags nohidden ~/Library
 
+# Show the /Users folder
+sudo chflags nohidden /Users
+
 # Remove Dropbox’s green checkmark icons in Finder
 file=/Applications/Dropbox.app/Contents/Resources/emblem-dropbox-uptodate.icns
 [ -e "${file}" ] && mv -f "${file}" "${file}.bak"


### PR DESCRIPTION
The folder is hidden by default starting with 10.9.3
