### PR TITLE
AddressBook debug menu doesn't work on Mavericks

### DIFF
--- a/.osx
+++ b/.osx
@@ -581,7 +581,7 @@ defaults write com.apple.ActivityMonitor SortDirection -int 0
 # Address Book, Dashboard, iCal, TextEdit, and Disk Utility                   #
 ###############################################################################
 
-# Enable the debug menu in Address Book
+# Enable the debug menu in Address Book (pre-10.8)
 defaults write com.apple.addressbook ABShowDebugMenu -bool true
 
 # Enable Dashboard dev mode (allows keeping widgets on the desktop)


### PR DESCRIPTION
Command to enable AddressBook debug menu doesn't work in OSX 10.8 and later versions
