### PR TITLE
Updated .gitconfig with the `push.default=simple`

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -117,6 +117,11 @@
 	# Include summaries of merged commits in newly created merge commit messages
 	log = true
 
+[push]
+
+	# Only pushes the current branch to the corresponding remote branch
+	default = simple
+
 # URL shorthands
 
 [url "git@github.com:"]


### PR DESCRIPTION
To get rid of the default message with the latest git 2.0

```
Git 2.0 from 'matching' to 'simple'. To squelch this message
and maintain the traditional behavior, use:

  git config --global push.default matching

To squelch this message and adopt the new behavior now, use:

  git config --global push.default simple

When push.default is set to 'matching', git will push local branches
to the remote branches that already exist with the same name.

Since Git 2.0, Git defaults to the more conservative 'simple'
behavior, which only pushes the current branch to the corresponding
remote branch that 'git pull' uses to update the current branch.
```
