### PR TITLE
Resolving strange charachters in non Mac terminal, fixes #399

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -104,17 +104,17 @@ else
 fi;
 
 # Set the terminal title to the current working directory.
-PS1="\[\033]0;\w\007\]";
-PS1+="\[${bold}\]\n"; # newline
-PS1+="\[${userStyle}\]\u"; # username
-PS1+="\[${white}\] at ";
-PS1+="\[${hostStyle}\]\h"; # host
-PS1+="\[${white}\] in ";
-PS1+="\[${green}\]\w"; # working directory
+PS1="\033]0;\w\007";
+PS1+="${bold}\n"; # newline
+PS1+="${userStyle}\u"; # username
+PS1+="${white} at ";
+PS1+="${hostStyle}\h"; # host
+PS1+="${white} in ";
+PS1+="${green}\w"; # working directory
 PS1+="\$(prompt_git \"${white} on ${violet}\")"; # Git repository details
 PS1+="\n";
-PS1+="\[${white}\]\$ \[${reset}\]"; # `$` (and reset color)
+PS1+="${white}\$ ${reset}"; # `$` (and reset color)
 export PS1;
 
-PS2="\[${yellow}\]→ \[${reset}\]";
+PS2="${yellow}→ ${reset}";
 export PS2;


### PR DESCRIPTION
Looks like the double inclusion of escaping characters (once in their definition, once in output line) was giving me trouble in Linux. Give it a try on a mac (or I will tonight).
