### PR TITLE
Added svn info to bash prompt

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -17,7 +17,7 @@ prompt_svn() {
   # Check if 'svn info' returned anything
   if [[ "$info" ]]; then
     # Parse the branch/tag/trunk name using awk, & return the last part only
-    branchName="$(echo "$info" | awk -F / '/URL:/ {print $NF}')"
+    branchName="$(echo "$info" | awk -F / '/Working Copy Root Path:/ {print $NF}')"
     # Get last and current revision #s
     last="$(echo "$info" | awk '/Last Changed Rev:/ {print $4}')"
     current="$(echo "$info" | awk '/Revision:/ {print $2}')"


### PR DESCRIPTION
Added a prompt_svn() function, which will parse out the branch name and revision range for any directories containing svn checkouts; the parsed svn info will be printed much like the git info
