### PR TITLE
.osx: Remove indicator lights boolean.

### DIFF
--- a/.osx
+++ b/.osx
@@ -359,9 +359,6 @@ defaults write com.apple.dock minimize-to-application -bool true
 # Enable spring loading for all Dock items
 defaults write com.apple.dock enable-spring-load-actions-on-all-items -bool true
 
-# Show indicator lights for open applications in the Dock
-defaults write com.apple.dock show-process-indicators -bool true
-
 # Wipe all (default) app icons from the Dock
 # This is only really useful when setting up a new Mac, or if you don’t use
 # the Dock to launch apps.


### PR DESCRIPTION
Remove "Show indicator lights for open applications in the Dock" from `.osx` file. This is default behaviour.
