### PR TITLE
Treat .md files as Markdown

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -100,4 +100,6 @@ if has("autocmd")
 	filetype on
 	" Treat .json files as .js
 	autocmd BufNewFile,BufRead *.json setfiletype json syntax=javascript
+	" Treat .md files as Markdown
+	autocmd BufNewFile,BufRead *.md setlocal filetype=markdown
 endif


### PR DESCRIPTION
Fixes #418.

![test.md fixed](https://cloud.githubusercontent.com/assets/205659/4004805/de60fbd4-2986-11e4-95a6-de0aa371ef1c.png)

[filetype](http://vimdoc.sourceforge.net/htmldoc/options.html#%3asetfiletype) is set implicitly, without using setfiletype, because `*.md` is already associated with Modula-2 files and `setfiletype` doesn't allow `filetype` to be set twice.

[setlocal](http://vimdoc.sourceforge.net/htmldoc/options.html#:setlocal) is used to apply a new `filetype` value for each Markdown file as it is being added to the buffer.
