### PR TITLE
Enable vim 'brackedted mode' (see http://stackoverflow.com/a/7053522/31493)

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -101,3 +101,19 @@ if has("autocmd")
 	" Treat .json files as .js
 	autocmd BufNewFile,BufRead *.json setfiletype json syntax=javascript
 endif
+
+" Enable "bracketed paste mode"
+" http://stackoverflow.com/a/7053522/31493
+if &term =~ "xterm.*"
+    let &t_ti = &t_ti . "\e[?2004h"
+    let &t_te = "\e[?2004l" . &t_te
+    function XTermPasteBegin(ret)
+        set pastetoggle=<Esc>[201~
+        set paste
+        return a:ret
+    endfunction
+    map <expr> <Esc>[200~ XTermPasteBegin("i")
+    imap <expr> <Esc>[200~ XTermPasteBegin("")
+    cmap <Esc>[200~ <nop>
+    cmap <Esc>[201~ <nop>
+endif


### PR DESCRIPTION
As of Mac OS X Lion 10.7, Terminal supports “bracketed paste mode,” which enables the terminal emulator to tell the program connected to the tty when the user pastes text, so that the program won’t interpret it as editing commands. Programs that support it send the terminal an escape sequence to enable this mode, in which the terminal surrounds pasted text with a pair of escape sequences that identify the start and end.
iTerm2 also supports this.
(code and description by Cris Page, see StackOverflow link)
