### PR TITLE
.gitconfig: Add alias to merge GitHub pull request

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -57,6 +57,18 @@
 	# List contributors with number of commits
 	contributors = shortlog --summary --numbered
 
+	# Merge GitHub pull request on top of the `master` branch
+	mpr = "!f() { \
+				if [ $(printf \"%s\" \"$1\" | grep '^[0-9]\\+$' > /dev/null; printf $?) -eq 0 ]; then \
+					git fetch origin refs/pull/$1/head:pr/$1 && \
+					git rebase master pr/$1 && \
+					git checkout master && \
+					git merge pr/$1 && \
+					git branch -D pr/$1 && \
+					git commit --amend -m \"$(git log -1 --pretty=%B)\n\nClose #$1\"; \
+				fi \
+			}; f"
+
 [apply]
 
 	# Detect whitespace errors when applying a patch


### PR DESCRIPTION
- Usage: 
  
  ``` bash
  $ cd /path/to/project/location
  $ git mpr <number>
  ```
- Description: 
  - Running `git mpr <number>` will checkout the content from the pull request with the specified number into a branch called `pr/<number>`, and, if the changes can be merged into master without any conflicts, it will merge them on top of the `master` and amend the commit message by adding `Close #<number>` at the end of it.
