### PR TITLE
Support multiple hosts in SSH completion

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -38,7 +38,7 @@ if type _git &> /dev/null && [ -f /usr/local/etc/bash_completion.d/git-completio
 fi;
 
 # Add tab completion for SSH hostnames based on ~/.ssh/config, ignoring wildcards
-[ -e "$HOME/.ssh/config" ] && complete -o "default" -o "nospace" -W "$(grep "^Host" ~/.ssh/config | grep -v "[?*]" | cut -d " " -f2 | tr ' ' '\n')" scp sftp ssh;
+[ -e "$HOME/.ssh/config" ] && complete -o "default" -o "nospace" -W "$(grep "^Host" ~/.ssh/config | grep -v "[?*]" | cut -d " " -f2- | tr ' ' '\n')" scp sftp ssh;
 
 # Add tab completion for `defaults read|write NSGlobalDomain`
 # You could just use `-g` instead, but I like being explicit


### PR DESCRIPTION
Useful in cases such as:

```
#.ssh/config

Host vm1 vm2 vm3 vm4
     Host localhost
     # ...
```

Simply adding a `-` to `tr` allows this
