### PR TITLE
Remove `export HOMEBREW_CASK_OPTS` from `.exports`

### DIFF
--- a/.exports
+++ b/.exports
@@ -20,6 +20,3 @@ export MANPAGER="less -X";
 
 # Always enable colored `grep` output
 export GREP_OPTIONS="--color=auto";
-
-# Link Homebrew casks in `/Applications` rather than `~/Applications`
-export HOMEBREW_CASK_OPTS="--appdir=/Applications";


### PR DESCRIPTION
This export is not needed anymore as the `Caskfile` has been removed
