### PR TITLE
.aliases: remove npmjs.eu reference

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -139,6 +139,3 @@ alias afk="/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resource
 
 # Reload the shell (i.e. invoke as a login shell)
 alias reload="exec $SHELL -l"
-
-# Faster npm for Europeans
-command -v npm > /dev/null && alias npme="npm --registry http://registry.npmjs.eu/"


### PR DESCRIPTION
So long, European npm mirror… Read the [depreciation notice](http://npmjs.eu)
