### PR TITLE
You can install Lua 5.2 now with "brew install lua"

### DIFF
--- a/.osx
+++ b/.osx
@@ -162,7 +162,7 @@ defaults -currentHost write NSGlobalDomain com.apple.trackpad.trackpadCornerClic
 defaults -currentHost write NSGlobalDomain com.apple.trackpad.enableSecondaryClick -bool true
 
 # Disable “natural” (Lion-style) scrolling
-#defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false
+defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false
 
 # Increase sound quality for Bluetooth headphones/headsets
 defaults write com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int 40


### PR DESCRIPTION
``` bash
dgitman at Davids-iMac in ~
$  brew info homebrew/versions/lua52
Error: No available formula for lua52 
Please tap it and then try again: brew tap homebrew/versions
```

You can install Lua 5.2 now with "brew install lua"
