### PR TITLE
Privacy: disable Spotlight suggestions from Safari

### DIFF
--- a/.osx
+++ b/.osx
@@ -439,6 +439,7 @@ defaults write com.apple.dock wvous-bl-modifier -int 0
 
 # Privacy: don’t send search queries to Apple
 defaults write com.apple.Safari UniversalSearchEnabled -bool false
+defaults write com.apple.Safari SuppressSearchSuggestions -bool true
 
 # Press Tab to highlight each item on a web page
 defaults write com.apple.Safari WebKitTabToLinksPreferenceKey -bool true


### PR DESCRIPTION
Safari has a "Spotlight Suggestions" setting that, if left enabled, will send a copy of all search queries to Apple. Info grabbed from [fix macosx](https://fix-macosx.com/).
