### PR TITLE
fix comment for menubar items

### DIFF
--- a/.osx
+++ b/.osx
@@ -27,7 +27,7 @@ sudo nvram SystemAudioVolume=" "
 # Disable transparency in the menu bar and elsewhere on Yosemite
 defaults write com.apple.universalaccess reduceTransparency -bool true
 
-# Menu bar: hide the Time Machine, Volume, User, and Bluetooth icons
+# Menu bar: hide the Time Machine, Volume, and User icons
 for domain in ~/Library/Preferences/ByHost/com.apple.systemuiserver.*; do
 	defaults write "${domain}" dontAutoLoad -array \
 		"/System/Library/CoreServices/Menu Extras/TimeMachine.menu" \


### PR DESCRIPTION
it says 'hide the Time Machine, Volume, User, and Bluetooth icons", but actually shows Bluetooth.
