### PR TITLE
`.gvimrc`: don't blink cursor in normal mode

### DIFF
--- a/.gvimrc
+++ b/.gvimrc
@@ -1,6 +1,8 @@
 " Use the Solarized Dark theme
 set background=dark
 colorscheme solarized
+" Don't blink cursor in normal mode
+set guicursor=n:blinkon0
 " Use 14pt Monaco
 set guifont=Monaco:h14
 " Better line-height


### PR DESCRIPTION
See https://github.com/mathiasbynens/dotfiles/issues/43.

Of course it's all personal preference, but blinking cursors are irritating. 