### PR TITLE
Greatly improve git tags alias

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -33,8 +33,15 @@ elif [ -f /etc/bash_completion ]; then
 fi;
 
 # Enable tab completion for `g` by marking it as an alias for `git`
-if type _git &> /dev/null && [ -f /usr/local/etc/bash_completion.d/git-completion.bash ]; then
-	complete -o default -o nospace -F _git g;
+if type _git &> /dev/null; then
+	if [ -f /usr/local/etc/bash_completion.d/git-completion.bash ]; then
+		complete -o default -o nospace -F _git g;
+	fi
+
+	# Add `git tags` completion
+	_git_tags() {
+		__gitcomp "$(git tag -l)";
+	}
 fi;
 
 # Add tab completion for SSH hostnames based on ~/.ssh/config, ignoring wildcards

--- a/.gitconfig
+++ b/.gitconfig
@@ -25,7 +25,6 @@
 	go = "!f() { git checkout -b \"$1\" 2> /dev/null || git checkout \"$1\"; }; f"
 
 	# Show verbose output about tags, branches or remotes
-	tags = tag -l
 	branches = branch -a
 	remotes = remote -v
 

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
-isValidTag() {
-  git rev-parse "$1" > /dev/null 2>&1 && echo 0 || echo 1;
-}
-
-getSHAbyTag() {
-  git rev-parse "$1";
-}
+TAG_MAX_LENGTH=20;
+OUTPUT_FORMAT="expanded";
+while getopts ":s" opt; do
+  case $opt in
+    s)
+      OUTPUT_FORMAT="small"
+      shift 1
+      ;;
+  esac
+done
 
 declare -A TEXT_COLORS
 TEXT_COLORS=(
@@ -16,9 +19,17 @@ TEXT_COLORS=(
   [NORMAL]="\033[0m"
 )
 
-TAG_MAX_LENGTH=20;
+
+isValidTag() {
+  git rev-parse "$1" > /dev/null 2>&1 && echo 0 || echo 1;
+}
+
+getSHAbyTag() {
+  git rev-parse "$1";
+}
+
 printTagInfo() {
-  local TAG=$1;
+  local TAG="$1";
 
   if [ $(isValidTag "$TAG") -ne 0 ]; then
     echo "\"$TAG\" is not a valid ref.";
@@ -41,27 +52,29 @@ printTagInfo() {
   printf "%*.*s" $(($TAG_MAX_LENGTH + 2 - ${#FORMATTED_TAG}));
   printf "${TEXT_COLORS[ORANGE]}%s${TEXT_COLORS[NORMAL]}\n" "$COMMIT_SHA";
 
-  printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-  printf "${TEXT_COLORS[BLUE]}\"%s\"${TEXT_COLORS[NORMAL]}\n" "$COMMIT_MESSAGE";
+  if [ $OUTPUT_FORMAT == "expanded" ]; then
+    printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
+    printf "${TEXT_COLORS[BLUE]}\"%s\"${TEXT_COLORS[NORMAL]}\n" "$COMMIT_MESSAGE";
 
 
-  printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-  printf "Author:";
-  printf "%*.*s" $((8 - $(expr length 'Author:')));
-  printf "%s\n" "$COMMIT_AUTHOR";
+    printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
+    printf "Author:";
+    printf "%*.*s" $((8 - $(expr length 'Author:')));
+    printf "%s\n" "$COMMIT_AUTHOR";
 
-  printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-  printf "Date:";
-  printf "%*.*s" $((8 - $(expr length 'Date:')));
-  printf "%s\n\n" "$COMMIT_DATE";
+    printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
+    printf "Date:";
+    printf "%*.*s" $((8 - $(expr length 'Date:')));
+    printf "%s\n\n" "$COMMIT_DATE";
+  fi
 }
 
 if [ $# -gt 0 ]; then
   # Find commit-SHA for specific tag.
-  printTagInfo $1;
+  printTagInfo "$1";
   exit 0;
 fi
 
 for tag in $(git tag -l); do
-  printTagInfo $tag;
+  printTagInfo "$tag";
 done

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -3,28 +3,40 @@
 TAG_MAX_LENGTH=20;
 OUTPUT_FORMAT="expanded";
 SHA_ONLY=false;
+
 while getopts ":sc" opt; do
   case $opt in
     s)
-      OUTPUT_FORMAT="small";
-      shift 1;
-      ;;
+    OUTPUT_FORMAT="small";
+    shift 1;
+    ;;
 
     c)
-      SHA_ONLY=true;
-      shift 1;
-      ;;
+    SHA_ONLY=true;
+    shift 1;
+    ;;
   esac
 done
 
-declare -A TEXT_COLORS;
-TEXT_COLORS=(
-  [GREEN]="\033[0;32m"
-  [ORANGE]="\033[0;33m"
-  [BLUE]="\033[0;34m"
-  [NORMAL]="\033[0m"
-)
+# declare -A TEXT_COLORS;
+# TEXT_COLORS=(
+#   [GREEN]="\033[0;32m"
+#   [ORANGE]="\033[0;33m"
+#   [BLUE]="\033[0;34m"
+#   [NORMAL]="\033[0m"
+# )
 
+# Define colors
+black='\033[0;30m'
+white='\033[0;37m'
+red='\033[0;31m'
+green='\033[0;32m'
+yellow='\033[0;33m'
+orange='\033[0;33m'
+blue='\033[0;34m'
+magenta='\033[0;35m'
+cyan='\033[0;36m'
+normal='\033[0m'
 
 isValidTag() {
   git rev-parse "$1" > /dev/null 2>&1;
@@ -62,23 +74,22 @@ printTagInfo() {
     FORMATTED_TAG="$TAG";
   fi
 
-  printf "${TEXT_COLORS[GREEN]}%s${TEXT_COLORS[NORMAL]}" "$FORMATTED_TAG";
+  printf "${green}%s${normal}" "$FORMATTED_TAG";
   printf "%*.*s" $(($TAG_MAX_LENGTH + 2 - ${#FORMATTED_TAG}));
-  printf "${TEXT_COLORS[ORANGE]}%s${TEXT_COLORS[NORMAL]}\n" "$COMMIT_SHA";
+  printf "${orange}%s${normal}\n" "$COMMIT_SHA";
 
   if [ $OUTPUT_FORMAT == "expanded" ]; then
     printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-    printf "${TEXT_COLORS[BLUE]}\"%s\"${TEXT_COLORS[NORMAL]}\n" "$COMMIT_MESSAGE";
-
+    printf "${blue}\"%s\"${normal}\n" "$COMMIT_MESSAGE";
 
     printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-    printf "Author:";
-    printf "%*.*s" $((8 - $(expr length 'Author:')));
+    printf "Author: ";
+    # printf "%*.*s" $((8 - $(expr length 'Author:')));
     printf "%s\n" "$COMMIT_AUTHOR";
 
     printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-    printf "Date:";
-    printf "%*.*s" $((8 - $(expr length 'Date:')));
+    printf "Date:   ";
+    # printf "%*.*s" $((8 - $(expr length 'Date:')));
     printf "%s\n\n" "$COMMIT_DATE";
   fi
 }

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -4,27 +4,35 @@ TAG_MAX_LENGTH=20;
 OUTPUT_FORMAT="expanded";
 SHA_ONLY=false;
 
-while getopts ":sc" opt; do
+help() {
+  printf "usage: git tags [options] <tagname...>\n\n";
+  printf "Tags options\n"
+  printf "\t-h        show this message\n"
+  printf "\t-c        only output commit SHA\n"
+  printf "\t-s        smaller (one-line) output\n"
+}
+
+while getopts "sch" opt; do
   case $opt in
     s)
-    OUTPUT_FORMAT="small";
-    shift 1;
-    ;;
+      OUTPUT_FORMAT="small";
+      ;;
 
     c)
-    SHA_ONLY=true;
-    shift 1;
-    ;;
+      SHA_ONLY=true;
+      ;;
+
+    *|h)
+      help;
+      if [ $opt == "h" ]; then
+        exit 0;
+      else
+        exit 1;
+      fi
+      ;;
   esac
 done
-
-# declare -A TEXT_COLORS;
-# TEXT_COLORS=(
-#   [GREEN]="\033[0;32m"
-#   [ORANGE]="\033[0;33m"
-#   [BLUE]="\033[0;34m"
-#   [NORMAL]="\033[0m"
-# )
+shift $(($OPTIND - 1))
 
 # Define colors
 black='\033[0;30m'
@@ -84,18 +92,16 @@ printTagInfo() {
 
     printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
     printf "Author: ";
-    # printf "%*.*s" $((8 - $(expr length 'Author:')));
     printf "%s\n" "$COMMIT_AUTHOR";
 
     printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
     printf "Date:   ";
-    # printf "%*.*s" $((8 - $(expr length 'Date:')));
     printf "%s\n\n" "$COMMIT_DATE";
   fi
 }
 
 if [ $# -gt 0 ]; then
-  # Find commit-SHA for specific tag.
+  # Find commit-SHA for specific tag(s).
   for tag in $@; do
     printTagInfo "$tag";
   done

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -85,7 +85,9 @@ printTagInfo() {
 
 if [ $# -gt 0 ]; then
   # Find commit-SHA for specific tag.
-  printTagInfo "$1";
+  for tag in $@; do
+    printTagInfo "$tag";
+  done
   exit 0;
 fi
 

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -1,36 +1,35 @@
 #!/usr/bin/env bash
 
-TAG_MAX_LENGTH=20;
-OUTPUT_FORMAT="expanded";
-SHA_ONLY=false;
+tag_max_length=20;
+output_format="expanded";
 
 help() {
-  printf "usage: git tags [options] <tagname...>\n\n";
-  printf "Tags options\n"
-  printf "\t-h        show this message\n"
-  printf "\t-c        only output commit SHA\n"
-  printf "\t-s        smaller (one-line) output\n"
+	printf "usage: git tags [options] <tagname...>\n\n";
+	printf "Tags options\n"
+	printf "\t-h        show this message\n"
+	printf "\t-c        only output commit SHA\n"
+	printf "\t-s        smaller (one-line) output\n"
 }
 
 while getopts "sch" opt; do
-  case $opt in
-    s)
-      OUTPUT_FORMAT="small";
-      ;;
+	case $opt in
+		s)
+			output_format="small";
+			;;
 
-    c)
-      SHA_ONLY=true;
-      ;;
+		c)
+			output_format="sha-only";
+			;;
 
-    *|h)
-      help;
-      if [ $opt == "h" ]; then
-        exit 0;
-      else
-        exit 1;
-      fi
-      ;;
-  esac
+		*|h)
+			help;
+			if [ $opt == "h" ]; then
+				exit 0;
+			else
+				exit 1;
+			fi
+			;;
+	esac
 done
 shift $(($OPTIND - 1))
 
@@ -46,68 +45,103 @@ magenta='\033[0;35m'
 cyan='\033[0;36m'
 normal='\033[0m'
 
-isValidTag() {
-  git rev-parse "$1" > /dev/null 2>&1;
-  echo $?;
+br() {
+	printf "\n";
 }
 
-getSHAbyTag() {
-  git rev-parse "$1";
+color-echo() {
+	printf "${2}${1}${normal}";
 }
 
-printTagInfo() {
-  local TAG="$1";
+ellipsis_trim() {
+	local max_length="${!#}";
+	local output="${@:1:$(($#-1))}";
 
-  isValid=$(isValidTag "$TAG");
-  if [ $isValid -ne 0 ]; then
-    echo "\"$TAG\" is not a valid ref. (exit code: $isValid)";
-    exit 1;
-  fi
+	if [ ${#output} -gt $max_length ]; then
+		echo "${output:0:$(($max_length - 3))}...";
+	else
+		echo "$output";
+	fi
+}
 
-  local COMMIT_SHA=$(getSHAbyTag $TAG);
+indent() {
+	local width="$1";
+	local pre_indent_length="$2";
+	if [ "$#" -ge 2 ]; then
+		width=$(($width - $pre_indent_length));
+	fi
+	printf "%*.*s" $width;
+}
 
-  if [ $SHA_ONLY == true ]; then
-    echo "$COMMIT_SHA";
-    return;
-  fi
+is_valid_tag() {
+	git rev-parse "$1" > /dev/null 2>&1;
+	echo $?;
+}
 
-  local COMMIT_MESSAGE=$(git show -s --format=%s "$COMMIT_SHA");
-  local COMMIT_AUTHOR=$(git --no-pager show -s --format='%an <%ae>' "$COMMIT_SHA");
-  local COMMIT_DATE=$(git --no-pager show -s --format='%ci' "$COMMIT_SHA");
-  local FORMATTED_TAG;
+get_SHA_by_tag() {
+	git rev-parse "$1";
+}
 
-  if [ ${#TAG} -gt $TAG_MAX_LENGTH ]; then
-    FORMATTED_TAG="${TAG:0:(($TAG_MAX_LENGTH - 3))}...";
-  else
-    FORMATTED_TAG="$TAG";
-  fi
+print_tag_info() {
+	local tag="$1";
 
-  printf "${green}%s${normal}" "$FORMATTED_TAG";
-  printf "%*.*s" $(($TAG_MAX_LENGTH + 2 - ${#FORMATTED_TAG}));
-  printf "${orange}%s${normal}\n" "$COMMIT_SHA";
+	local is_valid=$(is_valid_tag "$tag");
+	if [ $is_valid -ne 0 ]; then
+		echo "\"$tag\" is not a valid ref. (exit code: $is_valid)";
+		exit 1;
+	fi
 
-  if [ $OUTPUT_FORMAT == "expanded" ]; then
-    printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-    printf "${blue}\"%s\"${normal}\n" "$COMMIT_MESSAGE";
+	local commit_sha=$(get_SHA_by_tag $tag);
 
-    printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-    printf "Author: ";
-    printf "%s\n" "$COMMIT_AUTHOR";
+	if [ $output_format == "sha-only" ]; then
+		echo "$commit_sha";
+		return;
+	fi
 
-    printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
-    printf "Date:   ";
-    printf "%s\n\n" "$COMMIT_DATE";
-  fi
+	local commit_message=$(git show -s --format=%s "$commit_sha");
+	local commit_author=$(git --no-pager show -s --format='%an <%ae>' "$commit_sha");
+	local commit_date=$(git --no-pager show -s --format='%ci' "$commit_sha");
+
+	local formatted_tag=$(ellipsis_trim $tag $tag_max_length);
+
+	color-echo "$formatted_tag" $green;
+	indent $(($tag_max_length + 2)) ${#formatted_tag};
+	color-echo "$commit_sha" $orange;
+	br;
+
+	if [ $output_format == "expanded" ]; then
+		indent $(($tag_max_length + 2));
+		color-echo "$commit_message" $blue;
+		br;
+
+		indent $(($tag_max_length + 2));
+		printf "Author: ";
+		printf "%s" "$commit_author";
+		br;
+
+		indent $(($tag_max_length + 2));
+		printf "Date:   ";
+		printf "%s" "$commit_date";
+		br;
+	fi
+}
+
+print_tags() {
+	local last_tag=$(printf "$@" | tail -n 1);
+	for tag in $@; do
+		print_tag_info "$tag";
+		if \
+			[ $output_format == "expanded" ] 	&& \
+			[ $tag != $last_tag ];
+			then
+			br;
+		fi
+	done
 }
 
 if [ $# -gt 0 ]; then
-  # Find commit-SHA for specific tag(s).
-  for tag in $@; do
-    printTagInfo "$tag";
-  done
-  exit 0;
+	# Print meta data about passed tag(s).
+	print_tags $@;
+else
+	print_tags "$(git tag -l)";
 fi
-
-for tag in $(git tag -l); do
-  printTagInfo "$tag";
-done

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -131,7 +131,7 @@ print_tag_info() {
 }
 
 print_tags() {
-	local last_tag=$(printf "$@" | tail -n 1);
+	local last_tag="${@: -1}";
 	for tag in $@; do
 		print_tag_info "$tag";
 		if \
@@ -147,5 +147,5 @@ if [ $# -gt 0 ]; then
 	# Print meta data about passed tag(s).
 	print_tags $@;
 else
-	print_tags "$(git tag -l)";
+	print_tags $(git tag -l);
 fi

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -84,11 +84,17 @@ get_SHA_by_tag() {
 
 print_tag_info() {
 	local tag="$1";
+	local formatted_tag=$(ellipsis_trim $tag $tag_max_length);
 
 	local is_valid=$(is_valid_tag "$tag");
 	if [ $is_valid -ne 0 ]; then
-		echo "\"$tag\" is not a valid ref. (exit code: $is_valid)";
-		exit 1;
+		if [ $output_format != "sha-only" ]; then
+			color-echo "$formatted_tag" $red;
+			indent $(($tag_max_length + 2)) ${#formatted_tag};
+			color-echo "N/A" $red;
+			echo;
+		fi
+		return;
 	fi
 
 	local commit_sha=$(get_SHA_by_tag $tag);
@@ -101,8 +107,6 @@ print_tag_info() {
 	local commit_message=$(git show -s --format=%s "$commit_sha");
 	local commit_author=$(git --no-pager show -s --format='%an <%ae>' "$commit_sha");
 	local commit_date=$(git --no-pager show -s --format='%ci' "$commit_sha");
-
-	local formatted_tag=$(ellipsis_trim $tag $tag_max_length);
 
 	color-echo "$formatted_tag" $green;
 	indent $(($tag_max_length + 2)) ${#formatted_tag};

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -11,7 +11,7 @@ while getopts ":s" opt; do
   esac
 done
 
-declare -A TEXT_COLORS
+declare -A TEXT_COLORS;
 TEXT_COLORS=(
   [GREEN]="\033[0;32m"
   [ORANGE]="\033[0;33m"
@@ -21,7 +21,8 @@ TEXT_COLORS=(
 
 
 isValidTag() {
-  git rev-parse "$1" > /dev/null 2>&1 && echo 0 || echo 1;
+  git rev-parse "$1" > /dev/null 2>&1;
+  echo $?;
 }
 
 getSHAbyTag() {
@@ -31,8 +32,9 @@ getSHAbyTag() {
 printTagInfo() {
   local TAG="$1";
 
-  if [ $(isValidTag "$TAG") -ne 0 ]; then
-    echo "\"$TAG\" is not a valid ref.";
+  isValid=$(isValidTag "$TAG");
+  if [ $isValid -ne 0 ]; then
+    echo "\"$TAG\" is not a valid ref. (exit code: $isValid)";
     exit 1;
   fi
 

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -4,11 +4,11 @@ tag_max_length=20;
 output_format="expanded";
 
 help() {
-	printf "usage: git tags [options] <tagname...>\n\n";
-	printf "Tags options\n"
-	printf "\t-h        show this message\n"
-	printf "\t-c        only output commit SHA\n"
-	printf "\t-s        smaller (one-line) output\n"
+	printf "usage: git tags [options] [tagname ...]\n\n";
+	printf "Tags options\n";
+	printf "    -h        show this message\n";
+	printf "    -c        only output commit SHA\n";
+	printf "    -s        smaller (one-line) output\n";
 }
 
 while getopts "sch" opt; do

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -12,19 +12,21 @@ declare -A TEXT_COLORS
 TEXT_COLORS=(
   [GREEN]="\033[0;32m"
   [ORANGE]="\033[0;33m"
+  [BLUE]="\033[0;34m"
   [NORMAL]="\033[0m"
 )
 
-TAG_MAX_LENGTH=13;
+TAG_MAX_LENGTH=20;
 printTagInfo() {
   local TAG=$1;
 
   if [ $(isValidTag "$TAG") -ne 0 ]; then
-    echo "\"$TAG\" is not a valid ref."
+    echo "\"$TAG\" is not a valid ref.";
     exit 1;
   fi
 
   local COMMIT_SHA=$(getSHAbyTag $TAG);
+  local COMMIT_MESSAGE=$(git show -s --format=%s "$COMMIT_SHA");
   local COMMIT_AUTHOR=$(git --no-pager show -s --format='%an <%ae>' "$COMMIT_SHA");
   local COMMIT_DATE=$(git --no-pager show -s --format='%ci' "$COMMIT_SHA");
   local FORMATTED_TAG;
@@ -35,17 +37,23 @@ printTagInfo() {
     FORMATTED_TAG="$TAG";
   fi
 
-  printf "${TEXT_COLORS[GREEN]}%s${TEXT_COLORS[NORMAL]}" "$FORMATTED_TAG"
-  printf "%*.*s" $(($TAG_MAX_LENGTH + 2 - ${#FORMATTED_TAG}))
-  printf "${TEXT_COLORS[ORANGE]}%s${TEXT_COLORS[NORMAL]}\n" "$COMMIT_SHA"
+  printf "${TEXT_COLORS[GREEN]}%s${TEXT_COLORS[NORMAL]}" "$FORMATTED_TAG";
+  printf "%*.*s" $(($TAG_MAX_LENGTH + 2 - ${#FORMATTED_TAG}));
+  printf "${TEXT_COLORS[ORANGE]}%s${TEXT_COLORS[NORMAL]}\n" "$COMMIT_SHA";
 
-  printf "Author:"
-  printf "%*.*s" $((8 - $(expr length 'Author:')))
-  printf "%s\n" "$COMMIT_AUTHOR"
+  printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
+  printf "${TEXT_COLORS[BLUE]}\"%s\"${TEXT_COLORS[NORMAL]}\n" "$COMMIT_MESSAGE";
 
-  printf "Date:"
-  printf "%*.*s" $((8 - $(expr length 'Date:')))
-  printf "%s\n\n" "$COMMIT_DATE"
+
+  printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
+  printf "Author:";
+  printf "%*.*s" $((8 - $(expr length 'Author:')));
+  printf "%s\n" "$COMMIT_AUTHOR";
+
+  printf "%*.*s" $(($TAG_MAX_LENGTH + 2));
+  printf "Date:";
+  printf "%*.*s" $((8 - $(expr length 'Date:')));
+  printf "%s\n\n" "$COMMIT_DATE";
 }
 
 if [ $# -gt 0 ]; then

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+isValidTag() {
+  git rev-parse "$1" > /dev/null 2>&1 && echo 0 || echo 1;
+}
+
+getSHAbyTag() {
+  git rev-parse "$1";
+}
+
+declare -A TEXT_COLORS
+TEXT_COLORS=(
+  [GREEN]="\033[0;32m"
+  [ORANGE]="\033[0;33m"
+  [NORMAL]="\033[0m"
+)
+
+TAG_MAX_LENGTH=13;
+printTagInfo() {
+  local TAG=$1;
+
+  if [ $(isValidTag "$TAG") -ne 0 ]; then
+    echo "\"$TAG\" is not a valid ref."
+    exit 1;
+  fi
+
+  local COMMIT_SHA=$(getSHAbyTag $TAG);
+  local COMMIT_AUTHOR=$(git --no-pager show -s --format='%an <%ae>' "$COMMIT_SHA");
+  local COMMIT_DATE=$(git --no-pager show -s --format='%ci' "$COMMIT_SHA");
+  local FORMATTED_TAG;
+
+  if [ ${#TAG} -gt $TAG_MAX_LENGTH ]; then
+    FORMATTED_TAG="${TAG:0:(($TAG_MAX_LENGTH - 3))}...";
+  else
+    FORMATTED_TAG="$TAG";
+  fi
+
+  printf "${TEXT_COLORS[GREEN]}%s${TEXT_COLORS[NORMAL]}" "$FORMATTED_TAG"
+  printf "%*.*s" $(($TAG_MAX_LENGTH + 2 - ${#FORMATTED_TAG}))
+  printf "${TEXT_COLORS[ORANGE]}%s${TEXT_COLORS[NORMAL]}\n" "$COMMIT_SHA"
+
+  printf "Author:"
+  printf "%*.*s" $((8 - $(expr length 'Author:')))
+  printf "%s\n" "$COMMIT_AUTHOR"
+
+  printf "Date:"
+  printf "%*.*s" $((8 - $(expr length 'Date:')))
+  printf "%s\n\n" "$COMMIT_DATE"
+}
+
+if [ $# -gt 0 ]; then
+  # Find commit-SHA for specific tag.
+  printTagInfo $1;
+  exit 0;
+fi
+
+for tag in $(git tag -l); do
+  printTagInfo $tag;
+done

--- a/bin/git-tags
+++ b/bin/git-tags
@@ -2,11 +2,17 @@
 
 TAG_MAX_LENGTH=20;
 OUTPUT_FORMAT="expanded";
-while getopts ":s" opt; do
+SHA_ONLY=false;
+while getopts ":sc" opt; do
   case $opt in
     s)
-      OUTPUT_FORMAT="small"
-      shift 1
+      OUTPUT_FORMAT="small";
+      shift 1;
+      ;;
+
+    c)
+      SHA_ONLY=true;
+      shift 1;
       ;;
   esac
 done
@@ -39,6 +45,12 @@ printTagInfo() {
   fi
 
   local COMMIT_SHA=$(getSHAbyTag $TAG);
+
+  if [ $SHA_ONLY == true ]; then
+    echo "$COMMIT_SHA";
+    return;
+  fi
+
   local COMMIT_MESSAGE=$(git show -s --format=%s "$COMMIT_SHA");
   local COMMIT_AUTHOR=$(git --no-pager show -s --format='%an <%ae>' "$COMMIT_SHA");
   local COMMIT_DATE=$(git --no-pager show -s --format='%ci' "$COMMIT_SHA");


### PR DESCRIPTION
An enhancement of the current `git tags` alias. Shows in-depth information about tags, most importantly the commit-SHA it refers to. Comes with a `-s` option to only display tag name and its reference SHA and a `-c` option to only display the commit SHA.
I wrote this recently for my private dotfiles and find it extremely useful. My bash definitely isn't the best, I'm sure there is lots of room for improvement.

Thoughts?

*Preview (click image)*
<img src="http://i.imgur.com/QxKSK9y.jpg" width="150">

*Before*
<img src="http://i.imgur.com/OL5fD2Y.png" width="150">