### PR TITLE
Update .osx AppleHighlightColor to default

### DIFF
--- a/.osx
+++ b/.osx
@@ -41,6 +41,7 @@ defaults write com.apple.systemuiserver menuExtras -array \
 	"/System/Library/CoreServices/Menu Extras/Clock.menu"
 
 # Set highlight color to green
+# if want recovery to orginal "0.709800 0.835300 1.000000"
 defaults write NSGlobalDomain AppleHighlightColor -string "0.764700 0.976500 0.568600"
 
 # Set sidebar icon size to medium


### PR DESCRIPTION
add recovery original value.