### PR TITLE
.bash_prompt: prompt_svn() 2.0

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -9,6 +9,30 @@ elif infocmp xterm-256color >/dev/null 2>&1; then
 	export TERM='xterm-256color';
 fi;
 
+# Parse SVN Info. Inspired by @cowboy's prompt: https://github.com/cowboy/dotfiles
+prompt_svn() {
+  # Store output of 'svn info' in $info variable
+  local info="$(svn info . 2> /dev/null)"
+  local last current rootPath repoURL fullBranchPath branchName
+  # Check if 'svn info' returned anything
+  if [[ "$info" ]]; then
+    # Parse the WC root path, then call svn info again using this path to get the root checkout info
+    rootPath="$(echo "$info" | awk '/Working Copy Root Path:/ {print $NF}')"
+    info="$(svn info ${rootPath} 2> /dev/null)"
+    # Parse the repo root && full branch/tag/trunk path using awk
+    repoURL="$(echo "$info" | awk '/Repository Root:/ {print $NF}')"
+    repoURL="${repoURL//\//\\/}"
+    fullBranchPath="$(echo "$info" | awk '/URL:/ {print $NF}')"
+    # Replace full repo path with ^ (to get relative branch/tag/trunk path only)
+    branchName="${fullBranchPath/${repoURL}/^}"
+    # Get last and current revision #s
+    last="$(echo "$info" | awk '/Last Changed Rev:/ {print $4}')"
+    current="$(echo "$info" | awk '/Revision:/ {print $2}')"
+    # Put it all together now...
+    echo "${1}${branchName} ${blue}[${last}:${current}]"
+  fi
+}
+
 prompt_git() {
 	local s='';
 	local branchName='';
@@ -112,6 +136,7 @@ PS1+="\[${hostStyle}\]\h"; # host
 PS1+="\[${white}\] in ";
 PS1+="\[${green}\]\w"; # working directory
 PS1+="\$(prompt_git \"${white} on ${violet}\")"; # Git repository details
+PS1+="\$(prompt_svn \"${white} on ${violet}\")"; # SVN repository details
 PS1+="\n";
 PS1+="\[${white}\]\$ \[${reset}\]"; # `$` (and reset color)
 export PS1;


### PR DESCRIPTION
Updated prompt_svn() to pull the *correct* branch name, not the working copies root folder name; tested & working properly in sub-directories as well.

This update also includes the relative repository path. For example, the bash prompt will now show **^/branches/hello**, **^/tags/hello** or **^/hello**, instead of just **hello**.