### PR TITLE
.osx: Fix code that sets the custom terminal theme

### DIFF
--- a/.osx
+++ b/.osx
@@ -564,14 +564,51 @@ sudo mdutil -E / > /dev/null
 defaults write com.apple.terminal StringEncodings -array 4
 
 # Use a modified version of the Solarized Dark theme by default in Terminal.app
-TERM_PROFILE='Solarized Dark xterm-256color';
-CURRENT_PROFILE="$(defaults read com.apple.terminal 'Default Window Settings')";
-if [ "${CURRENT_PROFILE}" != "${TERM_PROFILE}" ]; then
-	open "${HOME}/init/${TERM_PROFILE}.terminal";
-	sleep 1; # Wait a bit to make sure the theme is loaded
-	defaults write com.apple.terminal 'Default Window Settings' -string "${TERM_PROFILE}";
-	defaults write com.apple.terminal 'Startup Window Settings' -string "${TERM_PROFILE}";
-fi;
+osascript <<EOD
+
+tell application "Terminal"
+
+	local allOpenedWindows
+	local initialOpenedWindows
+	local windowID
+	set themeName to "Solarized Dark xterm-256color"
+
+	(* Store the IDs of all the open terminal windows *)
+	set initialOpenedWindows to id of every window
+
+	(* Open the custom theme so that it gets added to the list
+	   of available terminal themes (note: this will open two
+	   additional terminal windows) *)
+	do shell script "open '$HOME/init/" & themeName & ".terminal'"
+
+	(* Wait a little bit to ensure that the custom theme is added *)
+	delay 1
+
+	(* Set the custom theme as the default terminal theme *)
+	set default settings to settings set themeName
+
+	(* Get the IDs of all the currently opened terminal windows *)
+	set allOpenedWindows to id of every window
+
+	repeat with windowID in allOpenedWindows
+
+		(* Close the additional windows that were opened in order
+		   to add the custom theme to the list of terminal themes *)
+		if initialOpenedWindows does not contain windowID then
+			close (every window whose id is windowID)
+
+		(* Change the theme for the initial opened terminal windows
+		   to remove the need to close them in order for the custom
+		   theme to be applied *)
+		else
+			set current settings of tabs of (every window whose id is windowID) to settings set themeName
+		end if
+
+	end repeat
+
+end tell
+
+EOD
 
 # Enable “focus follows mouse” for Terminal.app and all X11 apps
 # i.e. hover over a window and start typing in it without clicking first


### PR DESCRIPTION
This change will fix the problems described in #185 by making the `.osx` script correctly set the custom terminal theme, and make the change persistent.

For more information on how the code works, see the [inline comments](https://github.com/mathiasbynens/dotfiles/pull/492/files).

--

@mathiasbynens Some things to consider:

* I haven't tested for [iTerm2](http://iterm2.com/) (never used it)
* I also presume the [`init/` directory is in the `$HOME`](https://github.com/mathiasbynens/dotfiles/blob/7197c5739d7b54b6476dd0c54d9e34d41a42bdfd/.osx#L570), however, looking quickly through the code, I couldn't find how it gets there

-- 

Here is (basically the same) code in action:

![](https://cloud.githubusercontent.com/assets/1223565/6046297/74d6e506-aca9-11e4-81d1-137186521897.gif)


