### PR TITLE
Update bin/subl link to link from "Sublime Text.app" to "Sublime Text 2.app"

### DIFF
--- a/bin/subl
+++ b/bin/subl
@@ -1,1 +1,1 @@
-/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl
+/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl


### PR DESCRIPTION
The default install of the Sublime Text app uses the app filename of "Sublime Text 2.app".

This PR updates the bin/subl link to point to this new app name.