### PR TITLE
Install `io.js` and add aliases to switch to `io.js` / `Node.js`

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -139,3 +139,7 @@ alias afk="/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resource
 
 # Reload the shell (i.e. invoke as a login shell)
 alias reload="exec $SHELL -l"
+
+# Easily switch between `io.js` and `Node.js`
+alias use-iojs="brew unlink node && brew link --force iojs"
+alias use-node="brew unlink iojs && brew link --force node"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Suggestions/improvements
 * @ptb and [his _OS X Lion Setup_ repository](https://github.com/ptb/Mac-OS-X-Lion-Setup)
 * [Ben Alman](http://benalman.com/) and his [dotfiles repository](https://github.com/cowboy/dotfiles)
 * [Chris Gerke](http://www.randomsquared.com/) and his [tutorial on creating an OS X SOE master image](http://chris-gerke.blogspot.com/2012/04/mac-osx-soe-master-image-day-7.html) + [_Insta_ repository](https://github.com/cgerke/Insta)
-* [Cãtãlin Mariş](https://github.com/alrra) and his [dotfiles repository](https://github.com/alrra/dotfiles)
+* [Cătălin Mariș](https://github.com/alrra) and his [dotfiles repository](https://github.com/alrra/dotfiles)
 * [Gianni Chiappetta](http://gf3.ca/) for sharing his [amazing collection of dotfiles](https://github.com/gf3/dotfiles)
 * [Jan Moesen](http://jan.moesen.nu/) and his [ancient `.bash_profile`](https://gist.github.com/1156154) + [shiny _tilde_ repository](https://github.com/janmoesen/tilde)
 * [Lauri ‘Lri’ Ranta](http://lri.me/) for sharing [loads of hidden preferences](http://osxnotes.net/defaults.html)

--- a/brew.sh
+++ b/brew.sh
@@ -98,5 +98,8 @@ brew install zopfli
 # installation method.
 brew install node
 
+# Install io.js
+brew install iojs
+
 # Remove outdated versions from the cellar.
 brew cleanup


### PR DESCRIPTION
* Install `io.js`.
  https://iojs.org/en/index.html

* Add aliases to easily switch between `io.js` and `Node.js`.
  https://gist.github.com/phelma/ce4eeeedb8fb9a9e8e63