### PR TITLE
Add some networking stuff: revip() and asn()

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -52,6 +52,9 @@ alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
 alias localip="ipconfig getifaddr en0"
 alias ips="ifconfig -a | grep -o 'inet6\? \(addr:\)\?\s\?\(\(\([0-9]\+\.\)\{3\}[0-9]\+\)\|[a-fA-F0-9:]\+\)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"
 
+# Lookup my own ASN
+alias myasn='asn $(ip)'
+
 # Flush Directory Service cache
 alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
 

--- a/.functions
+++ b/.functions
@@ -259,7 +259,7 @@ function revip() {
 function asn() {
 	local ip=$1
 	if [[ ! "$1" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-		ip=$(dig +short +answer $1 in aaaa | head -n 1)
+		ip=$(dig +short +answer $1 in a | head -n 1)
 		if [[ -z "$ip" ]]; then
 			echo "DNS address lookup failed."
 			return 1

--- a/.functions
+++ b/.functions
@@ -244,3 +244,27 @@ function o() {
 function tre() {
 	tree -aC -I '.git|node_modules|bower_components' --dirsfirst "$@" | less -FRNX;
 }
+
+# Show an IP address in reverse form, i.e. `revip 1.2.3.4` => "4.3.2.1".
+# For IPv6: @see https://gist.github.com/lsowen/4447d916fd19cbb7fce4
+function revip() {
+	if [[ $1 =~ ":" ]]; then
+		echo "$1" | awk -F: 'BEGIN {OFS=""; }{addCount = 9 - NF; for(i=1; i<=NF;i++){if(length($i) == 0){ for(j=1;j<=addCount;j++){$i = ($i "0000");} } else { $i = substr(("0000" $i), length($i)+5-4);}}; print}' | rev | sed -e 's/./&./g' -e 's/.$//'
+	else
+		echo $1 | awk -F. '{print $4"."$3"."$2"."$1}'
+	fi
+}
+
+# Show the ASN number and some other information about an IP address or FQDN
+function asn() {
+	local ip=$1
+	if [[ ! "$1" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+		ip=$(dig +short +answer $1 in aaaa | head -n 1)
+		if [[ -z "$ip" ]]; then
+			echo "DNS address lookup failed."
+			return 1
+		fi
+	fi
+
+	dig +short +answer $(revip $ip).origin.asn.spameatingmonkey.net in txt | sed -e 's/^\"//g' -e 's/\"$//g'
+}


### PR DESCRIPTION
I added two shorthand functions:

```
# Get information about an IP (ASN number, owner, etc.). Works with domains, too.
# It simply looks up the IP at spameatingmonkey.net over DNS. Does not work with IPv6, unfortunately.
$ asn 8.8.8.8
8.8.8.0/24 | AS15169 | Google Inc. | 2000-03-30 | US
$ asn github.com
192.30.252.0/24 | AS36459 | GitHub, Inc. | 2012-11-13 | US
```

```
# Return an IP address in reverse form. Works with IPv6, too. Actually this is a helper function for asn().
$ revip 1.2.3.4
4.3.2.1
$ revip 2a00:1450:4016:803::1008
8.0.0.1.0.0.0.0.0.0.0.0.0.0.0.0.3.0.8.0.6.1.0.4.0.5.4.1.0.0.a.2
```

The alias `myasn` echoes the ASN info for the current `ip`.

Maybe this is of interest for anyone :)