### PR TITLE
Add ssh-copy-id to brew install

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -90,6 +90,7 @@ brew install pv
 brew install rename
 brew install rhino
 brew install speedtest_cli
+brew install ssh-copy-id
 brew install tree
 brew install webkit2png
 brew install zopfli


### PR DESCRIPTION
ssh-copy-id allows one to easily setup passwordless SSH connections on a new machine. It does this by copying over your public key and setting the correct permissions.

It becomes as simple as `ssh-copy-id user@hostname.example.com`. Probably safer than using manual or scripted methods.

More info here http://askubuntu.com/a/4833/42234