### PR TITLE
Preserve Bash History in Multiple Terminal Windows

### DIFF
--- a/.exports
+++ b/.exports
@@ -7,6 +7,9 @@ export HISTFILESIZE="${HISTSIZE}";
 # Omit duplicates and commands that begin with a space from history.
 export HISTCONTROL='ignoreboth';
 
+# After each command, append to the history file and reread it.
+export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND$'\n'}history -a; history -c; history -r";
+
 # Prefer US English and use UTF-8.
 export LANG='en_US.UTF-8';
 export LC_ALL='en_US.UTF-8';


### PR DESCRIPTION
I consistently have more than one terminal open. Anywhere from two to ten, doing various bits and bobs. Now let's say I restart and open up another set of terminals. Some remember certain things, some forget.

I want a history that:
- Remembers everything from every terminal.
- Is instantly accessible from every terminal (eg if I ls in one, switch to another already-running terminal and then press up, ls shows up).
- Doesn't forget random things if there are spaces at the front of the command.

[Taken from this StackExchange question.](https://unix.stackexchange.com/questions/1288/preserve-bash-history-in-multiple-terminal-windows)