### PR TITLE
Speedup Yosemite Wi-Fi

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -130,6 +130,10 @@ command -v grunt > /dev/null && alias grunt="grunt --stack"
 alias stfu="osascript -e 'set volume output muted true'"
 alias pumpitup="osascript -e 'set volume 7'"
 
+# Speedup Yosemite Wi-Fi by disabling AWDL
+alias fast="sudo ifconfig awdl0 down"
+alias slow="sudo ifconfig awdl0 up"
+
 # Kill all the tabs in Chrome to free up memory
 # [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
 alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"


### PR DESCRIPTION
Since the release of Yosemite users have experienced slow wireless connections. This is because of new a feature in Yosemite and iOS 8 called Apple Wireless Direct Link (AWDL). I've added aliases to turn it on and off.

> Please note that if you restart your computer this will go back to default and you will have to turn it off again - https://vinkla.com/posts/speedup-yosemite-wifi/