### PR TITLE
Add --all to brew upgrade

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -45,7 +45,7 @@ alias week='date +%V'
 alias timer='echo "Timer started. Stop with Ctrl-D." && date && time cat && date'
 
 # Get OS X Software Updates, and update installed Ruby gems, Homebrew, npm, and their installed packages
-alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update'
+alias update='sudo softwareupdate -i -a; brew update; brew upgrade --all; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update'
 
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"

--- a/brew.sh
+++ b/brew.sh
@@ -12,7 +12,7 @@ while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 brew update
 
 # Upgrade any already-installed formulae.
-brew upgrade
+brew upgrade --all
 
 # Install GNU core utilities (those that come with OS X are outdated).
 # Don’t forget to add `$(brew --prefix coreutils)/libexec/gnubin` to `$PATH`.


### PR DESCRIPTION
Brew recently started to hint that everyone should update their workflows for `brew upgrade` to use the new `--all` parameter.

> brew upgrade with no arguments will change behaviour soon! It currently upgrades all formula but this will soon change to require '--all'. Please update any workflows, documentation and scripts!

https://github.com/Homebrew/homebrew/commit/9032f165bec3d0c7452169093fab32578816043b