### PR TITLE
Fix issue when newline after 'prompt_git' call is removed

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -111,7 +111,7 @@ PS1+="\[${white}\] at ";
 PS1+="\[${hostStyle}\]\h"; # host
 PS1+="\[${white}\] in ";
 PS1+="\[${green}\]\w"; # working directory
-PS1+="\$(prompt_git \"${white} on ${violet}\")"; # Git repository details
+PS1+="\[\$(prompt_git \"${white} on ${violet}\")\]"; # Git repository details
 PS1+="\n";
 PS1+="\[${white}\]\$ \[${reset}\]"; # `$` (and reset color)
 export PS1;


### PR DESCRIPTION
When the newline after 'prompt_git' line is removed, we have issues for long lines, as they do not break properly.