### PR TITLE
Fix bash prompt issue if newline character is removed from PS1.

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -53,68 +53,72 @@ prompt_git() {
 
 		[ -n "${s}" ] && s=" [${s}]";
 
-		echo -e "${1}${branchName}${blue}${s}";
+		echo -e " on \[${violet}\]${branchName}\[${blue}\]${s}";
 	else
 		return;
 	fi;
 }
 
-if tput setaf 1 &> /dev/null; then
-	tput sgr0; # reset colors
-	bold=$(tput bold);
-	reset=$(tput sgr0);
-	# Solarized colors, taken from http://git.io/solarized-colors.
-	black=$(tput setaf 0);
-	blue=$(tput setaf 33);
-	cyan=$(tput setaf 37);
-	green=$(tput setaf 64);
-	orange=$(tput setaf 166);
-	purple=$(tput setaf 125);
-	red=$(tput setaf 124);
-	violet=$(tput setaf 61);
-	white=$(tput setaf 15);
-	yellow=$(tput setaf 136);
-else
-	bold='';
-	reset="\e[0m";
-	black="\e[1;30m";
-	blue="\e[1;34m";
-	cyan="\e[1;36m";
-	green="\e[1;32m";
-	orange="\e[1;33m";
-	purple="\e[1;35m";
-	red="\e[1;31m";
-	violet="\e[1;35m";
-	white="\e[1;37m";
-	yellow="\e[1;33m";
-fi;
+_install_custom_prompt() {
+	if tput setaf 1 &> /dev/null; then
+		tput sgr0; # reset colors
+		bold=$(tput bold);
+		reset=$(tput sgr0);
+		# Solarized colors, taken from http://git.io/solarized-colors.
+		black=$(tput setaf 0);
+		blue=$(tput setaf 33);
+		cyan=$(tput setaf 37);
+		green=$(tput setaf 64);
+		orange=$(tput setaf 166);
+		purple=$(tput setaf 125);
+		red=$(tput setaf 124);
+		violet=$(tput setaf 61);
+		white=$(tput setaf 15);
+		yellow=$(tput setaf 136);
+	else
+		bold='';
+		reset="\e[0m";
+		black="\e[1;30m";
+		blue="\e[1;34m";
+		cyan="\e[1;36m";
+		green="\e[1;32m";
+		orange="\e[1;33m";
+		purple="\e[1;35m";
+		red="\e[1;31m";
+		violet="\e[1;35m";
+		white="\e[1;37m";
+		yellow="\e[1;33m";
+	fi;
 
-# Highlight the user name when logged in as root.
-if [[ "${USER}" == "root" ]]; then
-	userStyle="${red}";
-else
-	userStyle="${orange}";
-fi;
+	# Highlight the user name when logged in as root.
+	if [[ "${USER}" == "root" ]]; then
+		userStyle="${red}";
+	else
+		userStyle="${orange}";
+	fi;
 
-# Highlight the hostname when connected via SSH.
-if [[ "${SSH_TTY}" ]]; then
-	hostStyle="${bold}${red}";
-else
-	hostStyle="${yellow}";
-fi;
+	# Highlight the hostname when connected via SSH.
+	if [[ "${SSH_TTY}" ]]; then
+		hostStyle="${bold}${red}";
+	else
+		hostStyle="${yellow}";
+	fi;
 
-# Set the terminal title to the current working directory.
-PS1="\[\033]0;\w\007\]";
-PS1+="\[${bold}\]\n"; # newline
-PS1+="\[${userStyle}\]\u"; # username
-PS1+="\[${white}\] at ";
-PS1+="\[${hostStyle}\]\h"; # host
-PS1+="\[${white}\] in ";
-PS1+="\[${green}\]\w"; # working directory
-PS1+="\$(prompt_git \"${white} on ${violet}\")"; # Git repository details
-PS1+="\n";
-PS1+="\[${white}\]\$ \[${reset}\]"; # `$` (and reset color)
-export PS1;
+	# Set the terminal title to the current working directory.
+	PS1="\[\033]0;\w\007\]";
+	PS1+="\[${bold}\]\n"; # newline
+	PS1+="\[${userStyle}\]\u"; # username
+	PS1+="\[${white}\] at ";
+	PS1+="\[${hostStyle}\]\h"; # host
+	PS1+="\[${white}\] in ";
+	PS1+="\[${green}\]\w"; # working directory
+	PS1+="\[${white}\]$(prompt_git)"; # Git repository details
+	PS1+="\n";
+	PS1+="\[${white}\]\$ \[${reset}\]"; # `$` (and reset color)
+	export PS1;
 
-PS2="\[${yellow}\]→ \[${reset}\]";
-export PS2;
+	PS2="\[${yellow}\]→ \[${reset}\]";
+	export PS2;
+}
+
+PROMPT_COMMAND="_install_custom_prompt; $PROMPT_COMMAND"


### PR DESCRIPTION
When the last newline character is removed (prompt is only one line long), we have issues with line breaks.

With the fix: ![https://s.leonklingele.de/1430848748](https://cloud.githubusercontent.com/assets/81942/7535867/0690f828-f58a-11e4-8f40-11a7f13d0095.png)

Without the fix: ![https://s.leonklingele.de/1430848765](https://cloud.githubusercontent.com/assets/81942/7535870/106902f0-f58a-11e4-928c-28206028b7ca.png)
