### PR TITLE
added  function for dir naviation

### DIFF
--- a/.functions
+++ b/.functions
@@ -244,3 +244,22 @@ function o() {
 function tre() {
 	tree -aC -I '.git|node_modules|bower_components' --dirsfirst "$@" | less -FRNX;
 }
+
+
+# `up` is a convenient way to navigate back up a file tree, and is a general-use
+# replacement for `cd ..`.
+# if no arguments are passed, up is simply an alias for `cd ..`. 
+# with any integer argument n, `cd ..` will be performed n times
+function up() {
+    # number of times to move up in the directory tree
+    TIMES=$1
+
+    if [ -z ${TIMES} ]; then
+        TIMES=1
+    fi
+    while [ ${TIMES} -gt 0 ]; do
+        cd ..
+        TIMES=$((${TIMES} - 1))
+    done
+}
+


### PR DESCRIPTION
Was looking through the .aliases file, and noticed the aliases for navigating up the tree.
``` bash
alias ..="cd .."
alias ...="cd ../.."
alias ....="cd ../../.."
alias .....="cd ../../../.."
```
I wanted to submit the function I've been using for a long while for your consideration. It's called `up` and it basically does what these aliases do, but as a function that takes an arbitrary integer argument, moving up in the directory tree that many times. If no argument is passed, it acts as an alias for `cd ..`.

``` bash
up    # cd ..
up 2  # cd ../..
up 7  # cd ../../../../../../..
```

This collection of dotfiles is rad, and I totally depend on them for my system config. Would be happy to help contribute, if only a small amount.

--Keith