### PR TITLE
prompt_git: indicate branch changes *behind* and *after*

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -41,6 +41,17 @@ prompt_git() {
 			if $(git rev-parse --verify refs/stash &>/dev/null); then
 				s+='$';
 			fi;
+			
+			# Check for changes behind & after
+			gitstatus=$(git status 2> /dev/null)
+
+			if [[ $gitstatus == *"behind"* ]]; then
+				s+='--';
+			fi;
+
+			if [[ $gitstatus == *"ahead"* ]]; then
+				s+='++';
+			fi;
 
 		fi;
 


### PR DESCRIPTION
based on the output of `git status`

e.g. 
>"Your branch is behind 'origin/master' by 19 commits [...]"