### PR TITLE
Move GREP_OPTIONS=--color=auto in .exports to aliases.

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -35,6 +35,14 @@ alias lsd="ls -lF ${colorflag} | grep --color=never '^d'"
 alias ls="command ls ${colorflag}"
 export LS_COLORS='no=00:fi=00:di=01;34:ln=01;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.avi=01;35:*.fli=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.ogg=01;35:*.mp3=01;35:*.wav=01;35:'
 
+
+# Move export GREP_OPTIONS="--color=auto" (which is deprecated in GNU grep) from
+# .exports to .aliases
+# Always enable colored `grep` output
+alias grep="grep --color=auto"
+alias fgrep="fgrep --color=auto"
+alias egrep="egrep --color=auto"
+
 # Enable aliases to be sudo’ed
 alias sudo='sudo '
 

--- a/.exports
+++ b/.exports
@@ -23,6 +23,3 @@ export LESS_TERMCAP_md="${yellow}";
 
 # Don’t clear the screen after quitting a manual page.
 export MANPAGER='less -X';
-
-# Always enable colored `grep` output.
-export GREP_OPTIONS='--color=auto';


### PR DESCRIPTION
@mathiasbynens

Mathias, at your call I've created this pull request. (See discussion in *issue* [GREP_OPTIONS is deprecated #467 ](https://github.com/mathiasbynens/dotfiles/issues/467."GREP_OPTIONS"))

Change GREP_OPTIONS=--color=auto in .exports to aliases to avoid errors.

File:       .exports, .aliases

The GREP_OPTIONS environment variable is deprecated in GNU grep 2.21.
(But not so in OS X grep 2.5.1-FreeBSD.)

To avoid errors such as this:

    $ env | grep -i grep
    grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
    GREP_OPTIONS=--color=auto
    
    $ grep --version
    grep (GNU grep) 2.21

grep color support was moved from .exports to .aliases as follows:

Remove from .exports:

    # Always enable colored grep output
    export GREP_OPTIONS="--color=auto"

Add to .aliases:

    # Move export GREP_OPTIONS="--color=auto" (which is deprecated in GNU grep)
    # from .exports to .aliases
    # Always enable colored grep output
    alias grep="grep --color=auto"
    alias fgrep="fgrep --color=auto"
    alias egrep="egrep --color=auto"