### PR TITLE
Secure empty trash has been removed.

### DIFF
--- a/.osx
+++ b/.osx
@@ -314,9 +314,6 @@ defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 # Disable the warning before emptying the Trash
 defaults write com.apple.finder WarnOnEmptyTrash -bool false
 
-# Empty Trash securely by default
-defaults write com.apple.finder EmptyTrashSecurely -bool true
-
 # Enable AirDrop over Ethernet and on unsupported Macs running Lion
 defaults write com.apple.NetworkBrowser BrowseAllInterfaces -bool true
 


### PR DESCRIPTION
This feature is no longer available.

`defaults` command is no effect on OSX El Capitan:

![screen shot 2015-11-03 at 10 06 22](https://cloud.githubusercontent.com/assets/159718/10904334/c03d2fac-8212-11e5-8d7d-84345ccb12c9.png)

Source: https://twitter.com/ryantate/status/660193276528562176