### PR TITLE
Fix tap to click for El Capitan

### DIFF
--- a/.osx
+++ b/.osx
@@ -154,7 +154,7 @@ sudo pmset -a sms 0
 ###############################################################################
 
 # Trackpad: enable tap to click for this user and for the login screen
-defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
+defaults write com.apple.AppleMultitouchTrackpad Clicking -int 1
 defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 defaults write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 


### PR DESCRIPTION
The tap to click instructions did not work in El Capitan (10.10.5).  I fixed so the tap to click will work (does require restart).  It appears global tap to click settings still don't work, but I'm not sure how to fix those.
