### PR TITLE
improve terminal title

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -104,7 +104,7 @@ else
 fi;
 
 # Set the terminal title to the current working directory.
-PS1="\[\033]0;\w\007\]";
+PS1="\033]0; ${PWD##*/}\007";
 PS1+="\[${bold}\]\n"; # newline
 PS1+="\[${userStyle}\]\u"; # username
 PS1+="\[${white}\] at ";


### PR DESCRIPTION
This will set the title of the current terminal tab to the name of the folder you are in (NOT the whole path).

### Before

<img width="832" alt="screen shot 2016-02-14 at 10 45 29 am" src="https://cloud.githubusercontent.com/assets/6316590/13031104/c5104742-d313-11e5-92e6-f7582b73bfdb.png">


### After

<img width="832" alt="screen shot 2016-02-14 at 12 06 01 pm" src="https://cloud.githubusercontent.com/assets/6316590/13031105/c9000086-d313-11e5-965d-55c44c04f69c.png">

Title space is limited. Showing the whole path makes it hard to know my base path.