### PR TITLE
Disable OSX Command-Ctrl-d keyboard shortcut

### DIFF
--- a/.osx
+++ b/.osx
@@ -203,6 +203,10 @@ defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
 # Stop iTunes from responding to the keyboard media keys
 #launchctl unload -w /System/Library/LaunchAgents/com.apple.rcd.plist 2> /dev/null
 
+# When using Command key as Meta key on Emacs GUI version, Command-Ctrl-d (C-M-d)
+# shortcut does not work unless the system wide OSX shortcut has been disabled.
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 70 '<dict><key>enabled</key><false/></dict>'
+
 ###############################################################################
 # Screen                                                                      #
 ###############################################################################


### PR DESCRIPTION
* It's very common amongst Emacs users to use Command key as Meta
  key. When running Emacs GUI with Command as Meta key, by default C-M-d
  shortcut does not work since Comamnd-Ctrl-d shortcut on OSX is
  globally assigned to finding the definition of a word.
* This commit disables Command-Ctrl-d as global shortcut for OSX,
  favouring Emacs users.