### PR TITLE
Symlink subl binary into $PATH

### DIFF
--- a/.osx
+++ b/.osx
@@ -758,6 +758,9 @@ defaults write com.irradiatedsoftware.SizeUp ShowPrefsOnNextStart -bool false
 # Install Sublime Text settings
 cp -r init/Preferences.sublime-settings ~/Library/Application\ Support/Sublime\ Text*/Packages/User/Preferences.sublime-settings 2> /dev/null
 
+# Symlink subl binary into default $PATH
+ln -s "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl" /usr/local/bin/subl
+
 ###############################################################################
 # Transmission.app                                                            #
 ###############################################################################


### PR DESCRIPTION
I'm having problems with `subl` command in fish shell without this fix. Maybe this will help others too.

Source:
http://stackoverflow.com/questions/11889484/command-subl-from-terminal-dont-work