### PR TITLE
add `o-github` function

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -46,3 +46,10 @@ complete -W "NSGlobalDomain" defaults;
 
 # Add `killall` tab completion for common apps
 complete -o "nospace" -W "Contacts Calendar Dock Finder Mail Safari iTunes SystemUIServer Terminal Twitter" killall;
+
+# Add `o-github` tab completion
+_o-github() {
+	local cur=${COMP_WORDS[COMP_CWORD]}
+	COMPREPLY=($(compgen -W "$(git remote)" -- $cur))
+}
+complete -F _o-github o-github

--- a/.functions
+++ b/.functions
@@ -244,3 +244,10 @@ function o() {
 function tre() {
 	tree -aC -I '.git|node_modules|bower_components' --dirsfirst "$@" | less -FRNX;
 }
+
+function o-github() {
+	[[ -z $1 ]] && set origin;
+	local slug=$(git remote get-url $1 | sed -n 's/.*:\(.*\)$/\1/p');
+	[[ $slug =~ .+\/.+ ]] || { echo "Couldn't parse remote url!"; return 1; };
+	open "https://github.com/${slug}";
+}


### PR DESCRIPTION
Opens the repo page for the specified remote (defaults to `origin`), in your default browser.

![sdaas1](https://cloud.githubusercontent.com/assets/6705160/13726584/308b0b30-e8cf-11e5-82de-89bf9bf66a64.gif)