### PR TITLE
silence ```which brew``` stderr output

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -26,7 +26,7 @@ for option in autocd globstar; do
 done;
 
 # Add tab completion for many Bash commands
-if which brew > /dev/null && [ -f "$(brew --prefix)/share/bash-completion/bash_completion" ]; then
+if which brew &> /dev/null && [ -f "$(brew --prefix)/share/bash-completion/bash_completion" ]; then
 	source "$(brew --prefix)/share/bash-completion/bash_completion";
 elif [ -f /etc/bash_completion ]; then
 	source /etc/bash_completion;


### PR DESCRIPTION
On RHEL6, ```which brew``` prints ```/usr/bin/which: no brew in ([...])``` to stderr. Changing 
```> /dev/null``` to ```&>/dev/null``` redirects both stdout and stderr to /dev/null, silencing the check completely. 