### PR TITLE
added feh aliases

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -147,3 +147,8 @@ alias afk="/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resource
 
 # Reload the shell (i.e. invoke as a login shell)
 alias reload="exec $SHELL -l"
+
+# feh - image viewer: always displays filename (tinted), verbose, full screen
+alias feh='feh -d --draw-tinted -V -F'
+# With EXIF information
+alias feh-exif='feh --draw-exif'


### PR DESCRIPTION
The image browser feh has some not nice defaults. Now it will open the images to fit the screen if they have resolution bigger than the monitor. It will also show the texts (like file name, number of images to display) in a transparent background.

Another alias (feh-exif) is to also display EXIF data. This is important when you want to check the characteristics of the camera (exposure time, aperture, ISO, focal length, etc...) when the picture was taken.