### PR TITLE
Respect alternate brew installation locations

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -2,6 +2,9 @@
 
 # Install command-line tools using Homebrew.
 
+# Save Homebrew's installed location
+BREW_PREFIX=$(brew --prefix)
+
 # Make sure we’re using the latest Homebrew.
 brew update
 
@@ -11,7 +14,7 @@ brew upgrade --all
 # Install GNU core utilities (those that come with OS X are outdated).
 # Don’t forget to add `$(brew --prefix coreutils)/libexec/gnubin` to `$PATH`.
 brew install coreutils
-ln -s /usr/local/bin/gsha256sum /usr/local/bin/sha256sum
+ln -s $BREW_PREFIX/bin/gsha256sum $BREW_PREFIX/bin/sha256sum
 
 # Install some other useful utilities like `sponge`.
 brew install moreutils
@@ -20,16 +23,14 @@ brew install findutils
 # Install GNU `sed`, overwriting the built-in `sed`.
 brew install gnu-sed --with-default-names
 # Install Bash 4.
-# Note: don’t forget to add `/usr/local/bin/bash` to `/etc/shells` before
-# running `chsh`.
 brew install bash
 brew tap homebrew/versions
 brew install bash-completion2
 
 # Switch to using brew-installed bash as default shell
-if ! fgrep -q '/usr/local/bin/bash' /etc/shells; then
-  echo '/usr/local/bin/bash' | sudo tee -a /etc/shells;
-  chsh -s /usr/local/bin/bash;
+if ! fgrep -q "$BREW_PREFIX/bin/bash" /etc/shells; then
+  echo "$BREW_PREFIX/bin/bash" | sudo tee -a /etc/shells;
+  chsh -s $BREW_PREFIX/bin/bash;
 fi;
 
 # Install `wget` with IRI support.


### PR DESCRIPTION
Existing approach assumes `brew` is installed in `/usr/local` and doesn't work as intended when it's installed elsewhere.
