### PR TITLE
Fancy ouput for targz()

### DIFF
--- a/.functions
+++ b/.functions
@@ -48,7 +48,7 @@ function targz() {
 		fi;
 	fi;
 
-	echo "Compressing .tar ($((size / 1000)) kb) using \`${cmd}\`…";
+	echo "Compressing .tar ($((size / 1000)) kB) using \`${cmd}\`…";
 	"${cmd}" -v "${tmpFile}" || return 1;
 	[ -f "${tmpFile}" ] && rm "${tmpFile}";
 
@@ -57,7 +57,7 @@ function targz() {
 		stat -c"%s" "${tmpFile}.gz" 2> /dev/null # GNU `stat`
 	);
 
-	echo "${tmpFile}.gz ($((zippedSize / 1000)) kb) created successfully.";
+	echo "${tmpFile}.gz ($((zippedSize / 1000)) kB) created successfully.";
 }
 
 # Determine size of a file or total size of a directory

--- a/.functions
+++ b/.functions
@@ -33,7 +33,7 @@ function targz() {
 
 	size=$(
 		stat -f"%z" "${tmpFile}" 2> /dev/null; # OS X `stat`
-		stat -c"%s" "${tmpFile}" 2> /dev/null # GNU `stat`
+		stat -c"%s" "${tmpFile}" 2> /dev/null;  # GNU `stat`
 	);
 
 	local cmd="";
@@ -54,7 +54,7 @@ function targz() {
 
 	zippedSize=$(
 		stat -f"%z" "${tmpFile}.gz" 2> /dev/null; # OS X `stat`
-		stat -c"%s" "${tmpFile}.gz" 2> /dev/null # GNU `stat`
+		stat -c"%s" "${tmpFile}.gz" 2> /dev/null; # GNU `stat`
 	);
 
 	echo "${tmpFile}.gz ($((zippedSize / 1000)) kB) created successfully.";

--- a/.functions
+++ b/.functions
@@ -48,10 +48,16 @@ function targz() {
 		fi;
 	fi;
 
-	echo "Compressing .tar using \`${cmd}\`…";
+	echo "Compressing .tar ($((size / 1000)) kb) using \`${cmd}\`…";
 	"${cmd}" -v "${tmpFile}" || return 1;
 	[ -f "${tmpFile}" ] && rm "${tmpFile}";
-	echo "${tmpFile}.gz created successfully.";
+
+	zippedSize=$(
+		stat -f"%z" "${tmpFile}.gz" 2> /dev/null; # OS X `stat`
+		stat -c"%s" "${tmpFile}.gz" 2> /dev/null # GNU `stat`
+	);
+
+	echo "${tmpFile}.gz ($((zippedSize / 1000)) kb) created successfully.";
 }
 
 # Determine size of a file or total size of a directory


### PR DESCRIPTION
added some text about the size of the tar and the tar.gz files:

> $ targz aclog
aclog/
[...]
aclog/aclog-20160208-2343(0).log
Compressing .tar (3020 kb) using `gzip`…
aclog.tar:	 78.4% -- replaced with aclog.tar.gz
aclog.tar.gz (651 kb) created successfully.
