### PR TITLE
add nvm to bash_profile

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -46,3 +46,7 @@ complete -W "NSGlobalDomain" defaults;
 
 # Add `killall` tab completion for common apps
 complete -o "nospace" -W "Contacts Calendar Dock Finder Mail Safari iTunes SystemUIServer Terminal Twitter" killall;
+
+# use node version manager
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm

--- a/.bash_profile
+++ b/.bash_profile
@@ -54,3 +54,6 @@ export NVM_DIR="$HOME/.nvm"
 #rbenv
 export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
+
+#gdal via KingChaos:
+export PATH=/Library/Frameworks/GDAL.framework/Programs:$PATH

--- a/.bash_profile
+++ b/.bash_profile
@@ -52,4 +52,5 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
 
 #rbenv
+export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"

--- a/.bash_profile
+++ b/.bash_profile
@@ -50,3 +50,6 @@ complete -o "nospace" -W "Contacts Calendar Dock Finder Mail Safari iTunes Syste
 # use node version manager
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+
+#rbenv
+eval "$(rbenv init -)"

--- a/.gitconfig
+++ b/.gitconfig
@@ -128,7 +128,7 @@
 [commit]
 
 	# https://help.github.com/articles/signing-commits-using-gpg/
-	gpgsign = true
+	# gpgsign = true
 
 [diff]
 

--- a/brew.sh
+++ b/brew.sh
@@ -21,7 +21,7 @@ brew install findutils
 brew install gnu-sed --with-default-names
 # Install Bash 4.
 # Note: don’t forget to add `/usr/local/bin/bash` to `/etc/shells` before
-# running `chsh`.
+# running `chsh -s /usr/local/bin/bash`.
 brew install bash
 brew tap homebrew/versions
 brew install bash-completion2
@@ -79,6 +79,7 @@ brew install tcptrace
 brew install ucspi-tcp # `tcpserver` etc.
 brew install xpdf
 brew install xz
+brew install jq
 
 # Install other useful binaries.
 brew install ack


### PR DESCRIPTION
For Node.JS users NVM is a helpful utility to have. Would need to add the install script somewhere to run though, open to suggestions for where to put it:

`curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.1/install.sh | bash`
