### PR TITLE
Add some more options for Transmission

### DIFF
--- a/.macos
+++ b/.macos
@@ -768,6 +768,7 @@ defaults write org.m0k.transmission IncompleteDownloadFolder -string "${HOME}/Do
 
 # Don’t prompt for confirmation before downloading
 defaults write org.m0k.transmission DownloadAsk -bool false
+defaults write org.m0k.transmission MagnetOpenAsk -bool false
 
 # Trash original torrent files
 defaults write org.m0k.transmission DeleteOriginalTorrent -bool true

--- a/.macos
+++ b/.macos
@@ -778,6 +778,11 @@ defaults write org.m0k.transmission WarningDonate -bool false
 # Hide the legal disclaimer
 defaults write org.m0k.transmission WarningLegal -bool false
 
+# IP block list.
+# Source: https://giuliomac.wordpress.com/2014/02/19/best-blocklist-for-transmission/
+defaults write org.m0k.transmission BlocklistURL -string "http://john.bitsurge.net/public/biglist.p2p.gz"
+defaults write org.m0k.transmission BlocklistAutoUpdate -bool true
+
 ###############################################################################
 # Twitter.app                                                                 #
 ###############################################################################


### PR DESCRIPTION
Namely:
* Do not prompt for download confirmation for magnet links.
* Add an IP block list.

@mathiasbynens : Feel free to tell me about the options you don't personally use. I'll comment those so you'll not be bothered by them but we'll still keep a reference for other users.