### PR TITLE
Add a section dedicated to iTunes

### DIFF
--- a/.macos
+++ b/.macos
@@ -197,9 +197,6 @@ sudo systemsetup -settimezone "Europe/Brussels" > /dev/null
 # Disable auto-correct
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
 
-# Stop iTunes from responding to the keyboard media keys
-#launchctl unload -w /System/Library/LaunchAgents/com.apple.rcd.plist 2> /dev/null
-
 ###############################################################################
 # Screen                                                                      #
 ###############################################################################
@@ -483,6 +480,13 @@ defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebK
 
 # Add a context menu item for showing the Web Inspector in web views
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
+
+###############################################################################
+# iTunes                                                                      #
+###############################################################################
+
+# Stop iTunes from responding to the keyboard media keys
+#launchctl unload -w /System/Library/LaunchAgents/com.apple.rcd.plist 2> /dev/null
 
 ###############################################################################
 # Mail                                                                        #


### PR DESCRIPTION
iTunes is so central to the whole macOS experience that it might need its own section for future configuration directives.