### PR TITLE
Disable efax daemon

### DIFF
--- a/.macos
+++ b/.macos
@@ -669,7 +669,7 @@ defaults write com.apple.TextEdit PlainTextEncoding -int 4
 defaults write com.apple.TextEdit PlainTextEncodingForWrite -int 4
 
 # Disable the receiving of faxes.
-sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.efax.plist
+sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.efax.plist 2> /dev/null
 
 # Enable the debug menu in Disk Utility
 defaults write com.apple.DiskUtility DUDebugMenuEnabled -bool true

--- a/.macos
+++ b/.macos
@@ -668,6 +668,9 @@ defaults write com.apple.TextEdit RichText -int 0
 defaults write com.apple.TextEdit PlainTextEncoding -int 4
 defaults write com.apple.TextEdit PlainTextEncodingForWrite -int 4
 
+# Disable the receiving of faxes.
+sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.efax.plist
+
 # Enable the debug menu in Disk Utility
 defaults write com.apple.DiskUtility DUDebugMenuEnabled -bool true
 defaults write com.apple.DiskUtility advanced-image-options -bool true


### PR DESCRIPTION
Faxes are old-school, and virtually unused. Disable the daemon to reclaim resources and reduce the attack surface.