### PR TITLE
Regroup and extend security options

### DIFF
--- a/.macos
+++ b/.macos
@@ -74,9 +74,6 @@ defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
 # Automatically quit printer app once the print jobs complete
 defaults write com.apple.print.PrintingPrefs "Quit When Finished" -bool true
 
-# Disable the “Are you sure you want to open this application?” dialog
-defaults write com.apple.LaunchServices LSQuarantine -bool false
-
 # Remove duplicates in the “Open With” menu (also see `lscleanup` alias)
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain system -domain user
 
@@ -89,9 +86,6 @@ defaults write com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool false
 
 # Disable automatic termination of inactive apps
 defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true
-
-# Disable the crash reporter
-#defaults write com.apple.CrashReporter DialogType -string "none"
 
 # Set Help Viewer windows to non-floating mode
 defaults write com.apple.helpviewer DevMode -bool true
@@ -128,6 +122,109 @@ defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
 #rm -rf ~/Library/Application Support/Dock/desktoppicture.db
 #sudo rm -rf /System/Library/CoreServices/DefaultDesktop.jpg
 #sudo ln -s /path/to/your/image /System/Library/CoreServices/DefaultDesktop.jpg
+
+##############################################################################
+# Security                                                                   #
+##############################################################################
+# Based on:
+# https://github.com/drduh/OS-X-Security-and-Privacy-Guide
+# https://benchmarks.cisecurity.org/tools2/osx/CIS_Apple_OSX_10.11_Benchmark_v1.0.0.pdf
+
+# Enable firewall. Possible values:
+#   0 = off
+#   1 = on for specific sevices
+#   2 = on for essential services
+#sudo defaults write /Library/Preferences/com.apple.alf globalstate -int 1
+
+# Enable stealth mode
+# Source: https://support.apple.com/kb/PH18642
+#sudo defaults write /Library/Preferences/com.apple.alf stealthenabled -int 1
+
+# Enable firewall logging
+#sudo defaults write /Library/Preferences/com.apple.alf loggingenabled -int 1
+
+# Do not automatically allow signed software to receive incoming connections
+#sudo defaults write /Library/Preferences/com.apple.alf allowsignedenabled -bool false
+
+# Log firewall events for 90 days
+#sudo perl -p -i -e 's/rotate=seq compress file_max=5M all_max=50M/rotate=utc compress file_max=5M ttl=90/g' "/etc/asl.conf"
+#sudo perl -p -i -e 's/appfirewall.log file_max=5M all_max=50M/appfirewall.log rotate=utc compress file_max=5M ttl=90/g' "/etc/asl.conf"
+
+# Reload the firewall
+# (uncomment if above is not commented out)
+#launchctl unload /System/Library/LaunchAgents/com.apple.alf.useragent.plist
+#sudo launchctl unload /System/Library/LaunchDaemons/com.apple.alf.agent.plist
+#sudo launchctl load /System/Library/LaunchDaemons/com.apple.alf.agent.plist
+#launchctl load /System/Library/LaunchAgents/com.apple.alf.useragent.plist
+
+# Disable IR remote control
+#sudo defaults write /Library/Preferences/com.apple.driver.AppleIRController DeviceEnabled -bool false
+
+# Turn Bluetooth off completely
+#sudo defaults write /Library/Preferences/com.apple.Bluetooth ControllerPowerState -int 0
+#sudo launchctl unload /System/Library/LaunchDaemons/com.apple.blued.plist
+#sudo launchctl load /System/Library/LaunchDaemons/com.apple.blued.plist
+
+# Disable wifi captive portal
+#sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.captive.control Active -bool false
+
+# Disable remote apple events
+#sudo systemsetup -setremoteappleevents off
+
+# Disable remote login
+#sudo systemsetup -setremotelogin off
+
+# Disable wake-on modem
+#sudo systemsetup -setwakeonmodem off
+
+# Disable wake-on LAN
+#systemsetup -setwakeonnetworkaccess off
+
+# Disable file-sharing via AFP or SMB
+#sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.AppleFileServer.plist
+#sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.smbd.plist
+
+# Display login window as name and password
+#sudo defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true
+
+# Do not show password hints
+#sudo defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0
+
+# Disable guest account login
+#sudo defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool false
+
+# Automatically lock the login keychain for inactivity after 6 hours
+#security set-keychain-settings -t 21600 -l ~/Library/Keychains/login.keychain
+
+# Destroy FileVault key when going into standby mode, forcing a re-auth.
+# Source: https://web.archive.org/web/20160114141929/http://training.apple.com/pdf/WP_FileVault2.pdf
+#sudo pmset destroyfvkeyonstandby 1
+
+# Disable Bonjour multicast advertisements
+#sudo defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true
+
+# Disable the crash reporter
+#defaults write com.apple.CrashReporter DialogType -string "none"
+
+# Disable diagnostic reports
+#sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.SubmitDiagInfo.plist
+
+# Log authentication events for 90 days
+#sudo perl -p -i -e 's/rotate=seq file_max=5M all_max=20M/rotate=utc file_max=5M ttl=90/g' "/etc/asl/com.apple.authd"
+
+# Log installation events for a year
+#sudo perl -p -i -e 's/format=bsd/format=bsd mode=0640 rotate=utc compress file_max=5M ttl=365/g' "/etc/asl/com.apple.install"
+
+# Increase the retention time for system.log and secure.log
+#sudo perl -p -i -e 's/\/var\/log\/wtmp.*$/\/var\/log\/wtmp   \t\t\t640\ \ 31\    *\t\@hh24\ \J/g' "/etc/newsyslog.conf"
+
+# Keep a log of kernel events for 30 days
+#sudo perl -p -i -e 's|flags:lo,aa|flags:lo,aa,ad,fd,fm,-all,^-fa,^-fc,^-cl|g' /private/etc/security/audit_control
+#sudo perl -p -i -e 's|filesz:2M|filesz:10M|g' /private/etc/security/audit_control
+#sudo perl -p -i -e 's|expire-after:10M|expire-after: 30d |g' /private/etc/security/audit_control
+
+# Disable the “Are you sure you want to open this application?” dialog
+defaults write com.apple.LaunchServices LSQuarantine -bool false
 
 ###############################################################################
 # SSD-specific tweaks                                                         #


### PR DESCRIPTION
Here is a collection of security enhancements for macOS.

I've tested all of them for several weeks on two machines running El Capitan (a MacBook Air and an iMac) without being annoyed by any of the proposed configurations. But for convenience, I made all of them optional to not mess with the regular user.

This PR is based on #306 and supersedes it.