### PR TITLE
Add support for negative value return to `calc()`

### DIFF
--- a/.functions
+++ b/.functions
@@ -8,12 +8,12 @@ function calc() {
 	#
 	if [[ "$result" == *.* ]]; then
 		# improve the output for decimal numbers
-		printf "$result" |
+		printf "%s" "$result" |
 		sed -e 's/^\./0./'        `# add "0" for cases like ".5"` \
 		    -e 's/^-\./-0./'      `# add "0" for cases like "-.5"`\
 		    -e 's/0*$//;s/\.$//';  # remove trailing zeros
 	else
-		printf "$result";
+		printf "%s" "$result";
 	fi;
 	printf "\n";
 }


### PR DESCRIPTION
Currently bash complains when `calc()` returns a negative value because `bash` it wants to evaluate the value as a flag
![screenshot](https://cloud.githubusercontent.com/assets/1546561/18030671/f1824a06-6c73-11e6-8184-ceb4fd66b32b.png)

Here I'm just adding a formatstring argument with a `%s` (string) format specifier to prevent that from happening