### PR TITLE
Keep System Preferences from Interfering.

### DIFF
--- a/.macos
+++ b/.macos
@@ -8,6 +8,10 @@ sudo -v
 # Keep-alive: update existing `sudo` time stamp until `.macos` has finished
 while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 
+# Kill system preferences to not have it trying to override config we're about
+# to change.
+osascript -e "tell application \"System Preferences\" to quit"
+
 ###############################################################################
 # General UI/UX                                                               #
 ###############################################################################


### PR DESCRIPTION
An open System Preferences window might overrides the settings we're trying to set.