### PR TITLE
fix manpage scrolling

### DIFF
--- a/.exports
+++ b/.exports
@@ -27,4 +27,4 @@ export LC_ALL='en_US.UTF-8';
 export LESS_TERMCAP_md="${yellow}";
 
 # Don’t clear the screen after quitting a manual page.
-export MANPAGER='less -X';
+export MANPAGER='less';


### PR DESCRIPTION
Using the `-X` flag for `less` does prevent the manpage from being cleared when exiting, but is also prevents scrolling down with the trackpad. This is very annoying with long manpages.