### PR TITLE
Fix activation of Transmission blocklist.

### DIFF
--- a/.macos
+++ b/.macos
@@ -837,6 +837,7 @@ defaults write org.m0k.transmission WarningLegal -bool false
 
 # IP block list.
 # Source: https://giuliomac.wordpress.com/2014/02/19/best-blocklist-for-transmission/
+defaults write org.m0k.transmission BlocklistNew -bool true
 defaults write org.m0k.transmission BlocklistURL -string "http://john.bitsurge.net/public/biglist.p2p.gz"
 defaults write org.m0k.transmission BlocklistAutoUpdate -bool true
 


### PR DESCRIPTION
Follow up on #679, in which I overlooked the required parameters to activate the option.

This PR fix the activation of peers blocklist in Transmission.

Thanks @helmedeiros for [the tip](https://github.com/mathiasbynens/dotfiles/pull/679#issuecomment-249398584)!