### PR TITLE
Removed pointless symlink in brew.sh

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -11,7 +11,6 @@ brew upgrade --all
 # Install GNU core utilities (those that come with macOS are outdated).
 # Don’t forget to add `$(brew --prefix coreutils)/libexec/gnubin` to `$PATH`.
 brew install coreutils
-ln -s /usr/local/bin/gsha256sum /usr/local/bin/sha256sum
 
 # Install some other useful utilities like `sponge`.
 brew install moreutils


### PR DESCRIPTION
```
ln -s /usr/local/bin/gsha256sum /usr/local/bin/sha256sum
```
This is pointless since the non-prefixed version is already in `gnubin`

https://github.com/Homebrew/brew/issues/1171#issuecomment-250906442