### PR TITLE
Remove no-op --all flag in brew upgrade calls

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -54,7 +54,7 @@ alias week='date +%V'
 alias timer='echo "Timer started. Stop with Ctrl-D." && date && time cat && date'
 
 # Get macOS Software Updates, and update installed Ruby gems, Homebrew, npm, and their installed packages
-alias update='sudo softwareupdate -i -a; brew update; brew upgrade --all; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update; sudo gem cleanup'
+alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update; sudo gem cleanup'
 
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"

--- a/brew.sh
+++ b/brew.sh
@@ -6,7 +6,7 @@
 brew update
 
 # Upgrade any already-installed formulae.
-brew upgrade --all
+brew upgrade
 
 # Install GNU core utilities (those that come with macOS are outdated).
 # Don’t forget to add `$(brew --prefix coreutils)/libexec/gnubin` to `$PATH`.


### PR DESCRIPTION
The following warning message shows up when upgrading the Homebrew packages:

> Warning: We decided to not change the behaviour of `brew upgrade` so `brew upgrade --all` is equivalent to `brew upgrade` without any other arguments (so the `--all` is a no-op and can be removed).

Removed the `--all` flags on brew upgrade calls.