### PR TITLE
allow mouse scrolling in man

### DIFF
--- a/.exports
+++ b/.exports
@@ -27,4 +27,4 @@ export LC_ALL='en_US.UTF-8';
 export LESS_TERMCAP_md="${yellow}";
 
 # Don’t clear the screen after quitting a manual page.
-export MANPAGER='less -X';
+export MANPAGER='less';

--- a/.exports
+++ b/.exports
@@ -26,5 +26,6 @@ export LC_ALL='en_US.UTF-8';
 # Highlight section titles in manual pages.
 export LESS_TERMCAP_md="${yellow}";
 
-# Don’t clear the screen after quitting a manual page.
+# Allow less's default behavior to use termcap. This allows mouse scrolling.
+# Change to 'less -X' to capture output in terminal and disable mouse scrolling.
 export MANPAGER='less';


### PR DESCRIPTION
@asafch This reverts the capture of man output in terminal.
An alternative would be a wrapper script like at:
http://unix.stackexchange.com/questions/107315/less-quit-if-one-screen-without-no-init/107355#107355
