### PR TITLE
.aliases: Add `ifactive`.  Lists active interfaces

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -61,6 +61,9 @@ alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
 alias localip="ipconfig getifaddr en0"
 alias ips="ifconfig -a | grep -o 'inet6\? \(addr:\)\?\s\?\(\(\([0-9]\+\.\)\{3\}[0-9]\+\)\|[a-fA-F0-9:]\+\)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"
 
+# Show active network interfaces
+alias ifactive="ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'"
+
 # Flush Directory Service cache
 alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
 


### PR DESCRIPTION
Handy for quickly chopping down the wall-of-text that is `ifconfig`.

Credit to g.rocket over at [Stack Exchange](https://unix.stackexchange.com/a/108048/6040).