### PR TITLE
Show boot-screen language menu selector

### DIFF
--- a/.macos
+++ b/.macos
@@ -188,6 +188,9 @@ defaults write NSGlobalDomain AppleLocale -string "en_GB@currency=EUR"
 defaults write NSGlobalDomain AppleMeasurementUnits -string "Centimeters"
 defaults write NSGlobalDomain AppleMetricUnits -bool true
 
+# Show language menu in the top right corner of the boot screen
+sudo defaults write /Library/Preferences/com.apple.loginwindow showInputMenu -bool true
+
 # Set the timezone; see `sudo systemsetup -listtimezones` for other values
 sudo systemsetup -settimezone "Europe/Brussels" > /dev/null
 


### PR DESCRIPTION
Show language menu in the top right corner of the boot screen.

So that non-US people fiddling with their locales and keyboards layout will not ends up locked out of their machine at boot time. See: https://apple.stackexchange.com/questions/23302/how-can-i-configure-the-keyboard-layout-for-the-filevault-2-unlock-screen