### PR TITLE
.macos: Enable firewall and set sensible defaults

### DIFF
--- a/.macos
+++ b/.macos
@@ -148,6 +148,22 @@ sudo chflags uchg /private/var/vm/sleepimage
 sudo pmset -a sms 0
 
 ###############################################################################
+# Firewall                                                                    #
+###############################################################################
+
+# Enable the firewall
+sudo defaults write /Library/Preferences/com.apple.alf globalstate -bool true
+
+# Allow built in software to receive incoming connections
+sudo defaults write /Library/Preferences/com.apple.alf allowsignedenabled -bool true
+
+# Allow downloaded and signed software to receive incoming connections
+sudo defaults write /Library/Preferences/com.apple.alf allowdownloadsignedenabled -bool true
+
+# Enable firewall stealth mode (no response to ICMP / ping requests)
+sudo defaults write /Library/Preferences/com.apple.alf stealthenabled -bool true
+
+###############################################################################
 # Trackpad, mouse, keyboard, Bluetooth accessories, and input                 #
 ###############################################################################
 


### PR DESCRIPTION
This enables the macOS firewall and also set sensible defaults such as enabling stealth mode (no response to ping / ICMP requests).