### PR TITLE
Use updated override for vim installation.

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -41,7 +41,7 @@ brew install ringojs
 brew install narwhal
 
 # Install more recent versions of some macOS tools.
-brew install vim --override-system-vi
+brew install vim --with-override-system-vi
 brew install homebrew/dupes/grep
 brew install homebrew/dupes/openssh
 brew install homebrew/dupes/screen


### PR DESCRIPTION
`brew` deprecated the previous flag:

```bash
Warning: vim: --override-system-vi was deprecated; using --with-override-system-vi instead!
```

Using the new flag...

