### PR TITLE
Clarify source for bash-completion

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -25,7 +25,7 @@ for option in autocd globstar; do
 	shopt -s "$option" 2> /dev/null;
 done;
 
-# Add tab completion for many Bash commands
+# Add tab completion for many Bash commands; requires `brew install homebrew/versions/bash-completion2`
 if which brew &> /dev/null && [ -f "$(brew --prefix)/share/bash-completion/bash_completion" ]; then
 	source "$(brew --prefix)/share/bash-completion/bash_completion";
 elif [ -f /etc/bash_completion ]; then

--- a/.bash_profile
+++ b/.bash_profile
@@ -25,7 +25,6 @@ for option in autocd globstar; do
 	shopt -s "$option" 2> /dev/null;
 done;
 
-# Add tab completion for many Bash commands; requires `brew install homebrew/versions/bash-completion2`
 if which brew &> /dev/null && [ -f "$(brew --prefix)/share/bash-completion/bash_completion" ]; then
 	source "$(brew --prefix)/share/bash-completion/bash_completion";
 elif [ -f /etc/bash_completion ]; then

--- a/.bash_profile
+++ b/.bash_profile
@@ -25,6 +25,7 @@ for option in autocd globstar; do
 	shopt -s "$option" 2> /dev/null;
 done;
 
+# Add tab completion for many Bash commands
 if which brew &> /dev/null && [ -f "$(brew --prefix)/share/bash-completion/bash_completion" ]; then
 	source "$(brew --prefix)/share/bash-completion/bash_completion";
 elif [ -f /etc/bash_completion ]; then

--- a/README.md
+++ b/README.md
@@ -81,13 +81,7 @@ When setting up a new Mac, you may want to install some common [Homebrew](http:/
 ./brew.sh
 ```
 
-Some of the functionality of these dotfiles leverages formulae installed by `brew.sh`. If you don't plan to run `brew.sh`, you should look carefully through the script and manually install any particularly important ones. A good example is bash/git completion: the dotfiles use a special version from Homebrew. To enable bash completion without running `brew.sh`:
-
-```bash
-brew install git
-brew tap homebrew/versions
-brew install bash-completion2
-```
+Some of the functionality of these dotfiles leverages formulae installed by `brew.sh`. If you don't plan to run `brew.sh`, you should look carefully through the script and manually install any particularly important ones. A good example is bash/git completion: the dotfiles use a special version from Homebrew. To enable bash completion without running `brew.sh`: `brew tap homebrew/versions && brew install git && brew install bash-completion2`.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ When setting up a new Mac, you may want to install some common [Homebrew](http:/
 ./brew.sh
 ```
 
+Some of the functionality of these dotfiles leverages formulae installed by `brew.sh`. If you don't plan to run `brew.sh`, you should look carefully through the script and manually install any particularly important ones. A good example is bash/git completion: the dotfiles use a special version from Homebrew. To enable bash completion without running `brew.sh`:
+
+```bash
+brew install git
+brew tap homebrew/versions
+brew install bash-completion2
+```
+
 ## Feedback
 
 Suggestions/improvements


### PR DESCRIPTION
I spent a solid 30 minutes debugging my git completion using these dotfiles. I had not yet run `brew.sh`. I had git completion installed, but it wasn't working because `.bash_profile` no longer separately sources `git-completion` in favor of the handy `bash-completion2`. I thought this note would be helpful to a common case where people have loaded the dotfiles but opted out of `brew.sh` and start poking around in `.bash_profile`, debugging their lack of git completion.

Thoughts?