### PR TITLE
Remove disabling of Sudden Motion Sensor for SSDs

### DIFF
--- a/.macos
+++ b/.macos
@@ -144,9 +144,6 @@ sudo touch /private/var/vm/sleepimage
 # …and make sure it can’t be rewritten
 sudo chflags uchg /private/var/vm/sleepimage
 
-# Disable the sudden motion sensor as it’s not useful for SSDs
-sudo pmset -a sms 0
-
 ###############################################################################
 # Trackpad, mouse, keyboard, Bluetooth accessories, and input                 #
 ###############################################################################


### PR DESCRIPTION
According to https://support.apple.com/en-gb/HT201666, Sudden Motion Sensor (SMS) is disabled by default for SSDs.

> Computers with Solid State Drives (SSD) or Flash Storage do not use SMS as the drives have no moving parts.

Can verify this with `pmset -g` and the `sms` setting should be missing. It may have value 0 if you explicitly disabled it.