### PR TITLE
Safari: also disable Java for local domains.

### DIFF
--- a/.macos
+++ b/.macos
@@ -516,6 +516,7 @@ defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebK
 # Disable Java
 defaults write com.apple.Safari WebKitJavaEnabled -bool false
 defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaEnabled -bool false
+defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaEnabledForLocalFiles -bool false
 
 # Block pop-up windows
 defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically -bool false


### PR DESCRIPTION
Java is currently disable for Safari in these dotfiles. The thing is: there is dedicated option to bypass this parameter for local files. This PR fix that by aligning the setting for both remote sites and local files.

Follows up on #684.