### PR TITLE
Do not rsync .macos

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,6 +8,7 @@ function doIt() {
 	rsync --exclude ".git/" \
 		--exclude ".DS_Store" \
 		--exclude ".osx" \
+		--exclude ".macos" \
 		--exclude "bootstrap.sh" \
 		--exclude "README.md" \
 		--exclude "LICENSE-MIT.txt" \


### PR DESCRIPTION
No need to put `.macos` executable into home dir.