### PR TITLE
Add flag for dry-run of rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Alternatively, to update while avoiding the confirmation prompt:
 set -- -f; source bootstrap.sh
 ```
 
+To perform a dry-run and list files which will be overwritten in your home directory:
+
+```bash
+set -- -n; source bootstrap.sh
+```
+
 ### Git-free install
 
 To install these dotfiles without Git:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,11 +11,14 @@ function doIt() {
 		--exclude "bootstrap.sh" \
 		--exclude "README.md" \
 		--exclude "LICENSE-MIT.txt" \
-		-avh --no-perms . ~;
+		-avh $1 --no-perms . ~;
 	source ~/.bash_profile;
 }
 
-if [ "$1" == "--force" -o "$1" == "-f" ]; then
+if [ "$1" == "--dry-run" -o "$1" == "-n" ]; then
+	echo "The following files will be overwritten in your home directory:";
+	doIt $1;
+elif [ "$1" == "--force" -o "$1" == "-f" ]; then
 	doIt;
 else
 	read -p "This may overwrite existing files in your home directory. Are you sure? (y/n) " -n 1;


### PR DESCRIPTION
I often want to know which files are going to change before I update my dotfiles. Since rsync has this built in, let's just pass the flag that rsync expects.

## Usage

    set -- -n; source bootstrap.sh

or

    set -- --dry-run; source bootstrap.sh

The option for a dry run is first such that `-f` or `--force` option doesn't have precedence should it be used in conjunction with a dry-run option.