### PR TITLE
.macos: Use sudo to `killall mds`

### DIFF
--- a/.macos
+++ b/.macos
@@ -586,7 +586,7 @@ defaults write com.apple.spotlight orderedItems -array \
 	'{"enabled" = 0;"name" = "MENU_WEBSEARCH";}' \
 	'{"enabled" = 0;"name" = "MENU_SPOTLIGHT_SUGGESTIONS";}'
 # Load new settings before rebuilding the index
-killall mds > /dev/null 2>&1
+sudo killall mds > /dev/null 2>&1
 # Make sure indexing is enabled for the main volume
 sudo mdutil -i on / > /dev/null
 # Rebuild the index from scratch


### PR DESCRIPTION
Using `killall mds` as unpriviledged user returns "No matching processes
belonging to you were found"