### PR TITLE
Drops --with-iri  in wget install

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -31,7 +31,7 @@ if ! fgrep -q '/usr/local/bin/bash' /etc/shells; then
 fi;
 
 # Install `wget` with IRI support.
-brew install wget --with-iri
+brew install wget
 
 # Install GnuPG to enable PGP-signing commits.
 brew install gnupg


### PR DESCRIPTION
`Warning: wget: this formula has no --with-iri option so it will be ignored!`