### PR TITLE
👌 IMPROVE: Disable Font Smoothing Disabler

### DIFF
--- a/.macos
+++ b/.macos
@@ -216,6 +216,10 @@ defaults write com.apple.screencapture disable-shadow -bool true
 # Reference: https://github.com/kevinSuttle/macOS-Defaults/issues/17#issuecomment-266633501
 defaults write NSGlobalDomain AppleFontSmoothing -int 1
 
+# Disable Font Smoothing Disabler in macOS Mojave
+# Reference: https://ahmadawais.com/fix-macos-mojave-font-rendering-issue/
+defaults write -g CGFontRenderingFontSmoothingDisabled -bool FALSE
+
 # Enable HiDPI display modes (requires restart)
 sudo defaults write /Library/Preferences/com.apple.windowserver DisplayResolutionEnabled -bool true
 


### PR DESCRIPTION
Disable Font Smoothing Disabler in macOS Mojave. It's a new issue and over 500 people have found my solution to be working great for them on social media and blog comments.

Thanks for the awesome repo! 