### PR TITLE
Don't show recent applications in Dock

### DIFF
--- a/.macos
+++ b/.macos
@@ -394,7 +394,7 @@ defaults write com.apple.dock autohide -bool true
 # Make Dock icons of hidden applications translucent
 defaults write com.apple.dock showhidden -bool true
 
-# Don't show recent applications in Dock
+# Don’t show recent applications in Dock
 defaults write com.apple.dock show-recents -bool false
 
 # Disable the Launchpad gesture (pinch with thumb and three fingers)

--- a/.macos
+++ b/.macos
@@ -394,6 +394,9 @@ defaults write com.apple.dock autohide -bool true
 # Make Dock icons of hidden applications translucent
 defaults write com.apple.dock showhidden -bool true
 
+# Don't show recent applications in Dock
+defaults write com.apple.dock show-recents -bool false
+
 # Disable the Launchpad gesture (pinch with thumb and three fingers)
 #defaults write com.apple.dock showLaunchpadGestureEnabled -int 0
 


### PR DESCRIPTION
As of macOS Mojave it will show a 'Recent Applications' section in the Dock by default. This change will instead hide that recent application section from the Dock.

![](https://user-images.githubusercontent.com/8009243/46193577-0097b400-c342-11e8-8dcc-b77c0e654127.png)

_It's strange committing to someone else's personal dotfiles, but I thought this was maybe a change you would use and I have borrowed so much from your dotfiles that I felt I should give back!_