### PR TITLE
Update comment to reflect change made in #818

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -27,7 +27,7 @@ fi
 # List all files colorized in long format
 alias l="ls -lF ${colorflag}"
 
-# List all files colorized in long format, including dot files
+# List all files colorized in long format, excluding . and ..
 alias la="ls -lAF ${colorflag}"
 
 # List only directories


### PR DESCRIPTION
Per #818, the change to using `ls -lA` means that the `.` and `..` files are now omitted from directory listings when using the `ll` alias.