### PR TITLE
Update bash-completion sourcing

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -26,8 +26,12 @@ for option in autocd globstar; do
 done;
 
 # Add tab completion for many Bash commands
-if which brew &> /dev/null && [ -f "$(brew --prefix)/share/bash-completion/bash_completion" ]; then
-	source "$(brew --prefix)/share/bash-completion/bash_completion";
+
+if which brew &> /dev/null && [ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]; then
+	# Ensure existing Homebrew v1 completions continue to work
+	export BASH_COMPLETION_COMPAT_DIR="$(brew --prefix)/etc/bash_completion.d"
+
+	source "$(brew --prefix)/etc/profile.d/bash_completion.sh"
 elif [ -f /etc/bash_completion ]; then
 	source /etc/bash_completion;
 fi;


### PR DESCRIPTION
The previous sourcing is replaced with what the current “caveats” specify (see `brew info bash-completion@2`)

And, thanks to Homebrew/homebrew-core#36254, any bash-completions meant for bash-completion v1 are now included, thanks to the env var.