### PR TITLE
Simplify git p alias

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -13,7 +13,7 @@
 	di = !"d() { git diff --patch-with-stat HEAD~$1; }; git diff-index --quiet HEAD -- || clear; d"
 
 	# Pull in remote changes for the current repository and all its submodules
-	p = !"git pull; git submodule foreach git pull origin master"
+	p = git pull --recurse-submodules
 
 	# Clone a repository including all submodules
 	c = clone --recursive


### PR DESCRIPTION
This uses the `git pull --recurse-submodules` argument to avoid the compound command of the previous version of this alias.