### PR TITLE
Update brew scripts and configs

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -49,7 +49,7 @@ alias sudo='sudo '
 alias week='date +%V'
 
 # Get macOS Software Updates, and update installed Ruby gems, Homebrew, npm, and their installed packages
-alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update; sudo gem cleanup'
+alias update='sudo softwareupdate -i -a; brew update; brew upgrade; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update; sudo gem cleanup'
 
 # Google Chrome
 alias chrome='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'

--- a/brew.sh
+++ b/brew.sh
@@ -32,7 +32,7 @@ if ! fgrep -q "${BREW_PREFIX}/bin/bash" /etc/shells; then
 fi;
 
 # Install `wget` with IRI support.
-brew install wget --with-iri
+brew install wget
 
 # Install GnuPG to enable PGP-signing commits.
 brew install gnupg

--- a/brew.sh
+++ b/brew.sh
@@ -9,7 +9,7 @@ brew upgrade
 BREW_PREFIX=$(brew --prefix)
 
 # Install GNU core utilities (those that come with macOS are outdated).
-# Don’t forget to add `$(brew --prefix coreutils)/libexec/gnubin` to `$PATH`.
+echo 'Be sure to add `$(brew --prefix coreutils)/libexec/gnubin` to `$PATH`.'
 brew install coreutils
 ln -s "${BREW_PREFIX}/bin/gsha256sum" "${BREW_PREFIX}/bin/sha256sum"
 

--- a/brew.sh
+++ b/brew.sh
@@ -2,9 +2,6 @@
 
 # Install command-line tools using Homebrew.
 
-# Make sure we’re using the latest Homebrew.
-brew update
-
 # Upgrade any already-installed formulae.
 brew upgrade
 

--- a/brew.sh
+++ b/brew.sh
@@ -38,7 +38,8 @@ brew install wget
 brew install gnupg
 
 # Install more recent versions of some macOS tools.
-brew install vim --with-override-system-vi
+brew install vim
+echo 'If you would like to map vi so it opens the brew-installed vim: ln -s /usr/local/bin/vim /usr/local/bin/vi'
 brew install grep
 brew install openssh
 brew install screen

--- a/brew.sh
+++ b/brew.sh
@@ -16,6 +16,7 @@ ln -s "${BREW_PREFIX}/bin/gsha256sum" "${BREW_PREFIX}/bin/sha256sum"
 # Install some other useful utilities like `sponge`.
 brew install moreutils
 # Install GNU `find`, `locate`, `updatedb`, and `xargs`, `g`-prefixed.
+echo 'Add `$(brew --prefix findutils)/libexec/gnubin` to `$PATH` if you would prefer these be the defaults.'
 brew install findutils
 # Install GNU `sed`, overwriting the built-in `sed`.
 brew install gnu-sed --with-default-names

--- a/brew.sh
+++ b/brew.sh
@@ -19,7 +19,7 @@ brew install moreutils
 brew install findutils
 # Install GNU `sed`, overwriting the built-in `sed`.
 brew install gnu-sed --with-default-names
-# Install Bash 4.
+# Install Bash 5.
 brew install bash
 brew install bash-completion2
 

--- a/brew.sh
+++ b/brew.sh
@@ -82,7 +82,7 @@ brew install ack
 #brew install exiv2
 brew install git
 brew install git-lfs
-brew install imagemagick --with-webp
+brew install imagemagick
 brew install lua
 brew install lynx
 brew install p7zip

--- a/brew.sh
+++ b/brew.sh
@@ -19,7 +19,8 @@ brew install moreutils
 echo 'Add `$(brew --prefix findutils)/libexec/gnubin` to `$PATH` if you would prefer these be the defaults.'
 brew install findutils
 # Install GNU `sed`, overwriting the built-in `sed`.
-brew install gnu-sed --with-default-names
+echo 'Be sure to add `$(brew --prefix gnu-sed)/libexec/gnubin` to `$PATH`.'
+brew install gnu-sed
 # Install Bash 5.
 brew install bash
 brew install bash-completion2

--- a/brew.sh
+++ b/brew.sh
@@ -95,6 +95,3 @@ brew install ssh-copy-id
 brew install tree
 brew install vbindiff
 brew install zopfli
-
-# Remove outdated versions from the cellar.
-brew cleanup


### PR DESCRIPTION
* Fixes #870 
* Fixes #869 

This updates a variety of things related to Homebrew:

* Drop unnecessarily running `brew cleanup` & `brew update`
* Add, and echo during script run, some suggestions re: `$PATH` for `coreutils`, `moreutils`, and `findutils`
* Drop Brew package arguments that are no longer present, and add additional instructions as-needed for `gnu-sed` (for the others, their defaults are now the same as what the args provided)