### PR TITLE
Update deprecated `--with-default-names` option in `brew.sh`

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -21,7 +21,8 @@ brew install moreutils
 # Install GNU `find`, `locate`, `updatedb`, and `xargs`, `g`-prefixed.
 brew install findutils
 # Install GNU `sed`, overwriting the built-in `sed`.
-brew install gnu-sed --with-default-names
+brew install gnu-sed
+export PATH=$(brew --prefix gnu-sed)/libexec/gnubin:$PATH
 # Install Bash 4.
 brew install bash
 brew install bash-completion2


### PR DESCRIPTION
`--with-default-names` option is no longer available for `brew install gnu-sed`. See https://github.com/Homebrew/homebrew-core/commit/068955e8cd698ac0286302fd244a4e4b42b47bab

So, instead, I propose adding `$(brew --prefix gnu-sed)/libexec/gnubin` to PATH.