### PR TITLE
Retrieve local ip independently

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -57,7 +57,7 @@ alias canary='/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Ch
 
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
-alias localip="ipconfig getifaddr en0"
+alias localip="echo $(ifconfig -a | grep -E 'UP|inet[^6]' | grep -A1 UP | grep inet | grep -v 127 | tail -1 | awk '{print $2}')"
 alias ips="ifconfig -a | grep -o 'inet6\? \(addr:\)\?\s\?\(\(\([0-9]\+\.\)\{3\}[0-9]\+\)\|[a-fA-F0-9:]\+\)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"
 
 # Show active network interfaces


### PR DESCRIPTION
Since MacOS doesn't necessarily name the cabled network interface `en0` the `localip` command fails  when WI-FI is down. This PR should fix this issue and resolve the local ip properly when connected via cable.