### PR TITLE
Per shellcheck, fgrep is deprecated

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -27,7 +27,7 @@ brew install bash
 brew install bash-completion2
 
 # Switch to using brew-installed bash as default shell
-if ! fgrep -q "${BREW_PREFIX}/bin/bash" /etc/shells; then
+if ! grep -Fq "${BREW_PREFIX}/bin/bash" /etc/shells; then
   echo "${BREW_PREFIX}/bin/bash" | sudo tee -a /etc/shells;
   chsh -s "${BREW_PREFIX}/bin/bash";
 fi;


### PR DESCRIPTION
Use `grep -F` instead.

Small thing, but shellcheck is pretty good about these things.