### PR TITLE
.macos: Show date next to time in menu bar

### DIFF
--- a/.macos
+++ b/.macos
@@ -93,6 +93,9 @@ defaults write com.apple.helpviewer DevMode -bool true
 # in the login window
 sudo defaults write /Library/Preferences/com.apple.loginwindow AdminHostInfo HostName
 
+# Show date and time in the menu bar
+defaults write com.apple.menuextra.clock "DateFormat" "EEE MMM d  H.mm"
+
 # Disable Notification Center and remove the menu bar icon
 launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist 2> /dev/null
 


### PR DESCRIPTION
I thought this would be useful to other people. It adds the date to the menu bar. 

![Screen Shot 2019-09-23 at 5 55 34 PM](https://user-images.githubusercontent.com/250892/65441829-5dca2680-de2b-11e9-9dde-ff4977e9ad58.png)

Same as setting it in System Preferences:

![Screen Shot 2019-09-23 at 5 57 23 PM](https://user-images.githubusercontent.com/250892/65442024-bc8fa000-de2b-11e9-89a1-c88e0f46949a.png)
