### PR TITLE
Correctly set git p alias

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -13,7 +13,7 @@
 	di = !"d() { git diff --patch-with-stat HEAD~$1; }; git diff-index --quiet HEAD -- || clear; d"
 
 	# Pull in remote changes for the current repository and all its submodules
-	p = git pull --recurse-submodules
+	p = pull --recurse-submodules
 
 	# Clone a repository including all submodules
 	c = clone --recursive


### PR DESCRIPTION
Fix a bug introduced in #868, originally proposed in #826