### PR TITLE
.macos: Remove `tmutil disablelocal`

### DIFF
--- a/.macos
+++ b/.macos
@@ -694,9 +694,6 @@ defaults write com.googlecode.iterm2 PromptOnQuit -bool false
 # Prevent Time Machine from prompting to use new hard drives as backup volume
 defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
 
-# Disable local Time Machine backups
-hash tmutil &> /dev/null && sudo tmutil disablelocal
-
 ###############################################################################
 # Activity Monitor                                                            #
 ###############################################################################


### PR DESCRIPTION
`disablelocal` option was removed in Sierra and haven't got back since then. And there is no known substitute.
Verified on Catalina.

```sh
hash tmutil &> /dev/null && sudo tmutil disablelocal
disablelocal: Unrecognized verb.
```

Closes #842.