### PR TITLE
aliases: update grep pattern in 'chromekill' alias.

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -136,7 +136,7 @@ alias pumpitup="osascript -e 'set volume output volume 100'"
 
 # Kill all the tabs in Chrome to free up memory
 # [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
-alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"
+alias chromekill="ps ux | grep '[C]hrome Helper (Renderer) --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"
 
 # Lock the screen (when going AFK)
 alias afk="/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend"


### PR DESCRIPTION
It seems that the alias was no longer working with Google Chrome Version 79.0.3945.130 (Official Build) (64-bit) on my macOS Catalina version 10.15.2. Adding '(Renderer)' to the grep pattern when searching for Google Chrome among the running processes, solves the problem.