### PR TITLE
Remove .gitignore from rsync

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,7 @@ git pull origin master;
 
 function doIt() {
 	rsync --exclude ".git/" \
+		--exclude ".gitignore" \
 		--exclude ".DS_Store" \
 		--exclude ".osx" \
 		--exclude "bootstrap.sh" \


### PR DESCRIPTION
I didn't see a reason to have the .gitignore file in. Please disregard if otherwise. 