### PR TITLE
Added some things so "git init" will default to main instead of master.

### DIFF
--- a/.config/git/template/HEAD
+++ b/.config/git/template/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/main

--- a/.gitconfig
+++ b/.gitconfig
@@ -188,3 +188,7 @@
 [url "git://gist.github.com/"]
 
 	insteadOf = "gist:"
+
+[init]
+
+	templateDir = ~/.config/git/template/


### PR DESCRIPTION
Like everything else ... stole from SO https://stackoverflow.com/questions/42871542/how-to-create-a-git-repository-with-the-default-branch-name-other-than-master/50880622#50880622

No this doesn't change this repo to use main, I figured that would require collaborators to do.

There are more things we could do ... see https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx

We could add alias or even functions to help convert existing repos.