### PR TITLE
Allow aliases to be used in vim shell commands

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Required for non-interactive bash, e.g. from vim
+shopt -s expand_aliases
+
 # Easier navigation: .., ..., ...., ....., ~ and -
 alias ..="cd .."
 alias ...="cd ../.."

--- a/.vimrc
+++ b/.vimrc
@@ -104,3 +104,7 @@ if has("autocmd")
 	" Treat .md files as Markdown
 	autocmd BufNewFile,BufRead *.md setlocal filetype=markdown
 endif
+
+" Allow vim to see aliases
+" Requires `shopt -s expand_aliases` in specified BASH_ENV file
+let $BASH_ENV = "~/.aliases"


### PR DESCRIPTION
Modified .vimrc and .aliases to allow aliases to be used in vim shell commands.

Reference: https://stackoverflow.com/a/18901595/6636894