### PR TITLE
Replace deprecated _git wrapper function 

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -35,8 +35,8 @@ elif [ -f /etc/bash_completion ]; then
 fi;
 
 # Enable tab completion for `g` by marking it as an alias for `git`
-if type _git &> /dev/null; then
-	complete -o default -o nospace -F _git g;
+if type __git_wrap__git_main &> /dev/null; then
+    complete -o default -o nospace -F __git_wrap__git_main g
 fi;
 
 # Add tab completion for SSH hostnames based on ~/.ssh/config, ignoring wildcards

--- a/.bash_profile
+++ b/.bash_profile
@@ -35,8 +35,8 @@ elif [ -f /etc/bash_completion ]; then
 fi;
 
 # Enable tab completion for `g` by marking it as an alias for `git`
-if type __git_wrap__git_main &> /dev/null; then
-    complete -o default -o nospace -F __git_wrap__git_main g
+if type __git_complete &> /dev/null; then
+    __git_complete g git
 fi;
 
 # Add tab completion for SSH hostnames based on ~/.ssh/config, ignoring wildcards


### PR DESCRIPTION
Currently when updating `git` on your machine you'll get version 2.32 which doesn't have the `_git` wrapper function anymore.

~~Replacing it with the `__git_wrap__git_main` that was proxied through `_git`.~~
As the git bash completion script mentions, it's possible to use "__git_complete" to make use of completion.

See:
https://github.com/git/git/commit/441ecdab37fefdacf32575a60aa523b2367c46f7
https://github.com/git/git/commit/5a067ba9d04eebc92ad77f101b785219238f4f1e (thanks @lucthev)
and https://github.com/git/git/blob/master/contrib/completion/git-completion.bash#L39