### PR TITLE
Fix for mosh and some other non-interactive shells

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,1 +1,10 @@
-[ -n "$PS1" ] && source ~/.bash_profile;
+# Only source ~/.bash_profile if interactive shell
+# Provide some extra PATH locations for things using a non-interactive shell
+# such as git-annex, mosh, and rsync via homebrew.
+
+if [[ -n "$PS1" ]] ; then
+	source ~/.bash_profile
+elif
+	PATH=$HOME/bin:/usr/local/bin:/opt/homebrew/bin:$PATH
+	return
+fi


### PR DESCRIPTION
If certain programs are installed that are not part of the base system, such as what is installed via homebrew, then they will not be found in a non-interactive shell.
Rsync and git will default to the system provided versions in /usr/bin, and programs like mosh-server and git-annex will not work at all.

More discussion here:
https://github.com/mobile-shell/mosh/issues/102#issuecomment-12503646